### PR TITLE
Enable the import-error pylint rule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,6 @@ ignore=stubs
 [MESSAGES CONTROL]
 
 disable=duplicate-code,
-        import-error,
         missing-module-docstring,
         no-member,
         no-name-in-module,


### PR DESCRIPTION
This rule would have caught the import bug in the first version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exabel/python-sdk/12)
<!-- Reviewable:end -->
