### PR TITLE
Add __repr__ to data classes

### DIFF
--- a/exabel_data_sdk/client/api/data_classes/entity.py
+++ b/exabel_data_sdk/client/api/data_classes/entity.py
@@ -66,3 +66,10 @@ class Entity:
             and self.properties == other.properties
             and self.read_only == other.read_only
         )
+
+    def __repr__(self) -> str:
+        return (
+            f"Entity(name='{self.name}', display_name='{self.display_name}', "
+            f"description='{self.description}', properties={self.properties}, "
+            f"read_only={self.read_only})"
+        )

--- a/exabel_data_sdk/client/api/data_classes/entity_type.py
+++ b/exabel_data_sdk/client/api/data_classes/entity_type.py
@@ -48,3 +48,9 @@ class EntityType:
             and self.description == other.description
             and self.read_only == other.read_only
         )
+
+    def __repr__(self) -> str:
+        return (
+            f"EntityType(name='{self.name}', display_name='{self.display_name}', "
+            f"description='{self.description}', read_only={self.read_only})"
+        )

--- a/exabel_data_sdk/client/api/data_classes/relationship.py
+++ b/exabel_data_sdk/client/api/data_classes/relationship.py
@@ -72,3 +72,11 @@ class Relationship:
             and self.properties == other.properties
             and self.read_only == other.read_only
         )
+
+    def __repr__(self) -> str:
+        return (
+            f"Relationship(relationship_type='{self.relationship_type}', "
+            f"from_entity='{self.from_entity}', to_entity='{self.to_entity}', "
+            f"description='{self.description}', properties={self.properties}, "
+            f"read_only={self.read_only})"
+        )

--- a/exabel_data_sdk/client/api/data_classes/relationship_type.py
+++ b/exabel_data_sdk/client/api/data_classes/relationship_type.py
@@ -60,3 +60,9 @@ class RelationshipType:
             and self.properties == other.properties
             and self.read_only == other.read_only
         )
+
+    def __repr__(self) -> str:
+        return (
+            f"RelationshipType(name='{self.name}', description='{self.description}', "
+            f"properties={self.properties}, read_only={self.read_only})"
+        )

--- a/exabel_data_sdk/client/api/data_classes/signal.py
+++ b/exabel_data_sdk/client/api/data_classes/signal.py
@@ -64,3 +64,10 @@ class Signal:
             and self.description == other.description
             and self.read_only == other.read_only
         )
+
+    def __repr__(self) -> str:
+        return (
+            f"Signal(name='{self.name}', entity_type='{self.entity_type}', "
+            f"display_name='{self.display_name}', description='{self.description}', "
+            f"read_only={self.read_only})"
+        )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="exabel-data-sdk",
-    version="0.0.3",
+    version="0.0.4",
     author="Exabel",
     author_email="support@exabel.com",
     description="Python SDK for the Exabel Data API",


### PR DESCRIPTION
The informative string representation disappeared when `@dataclass` was removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exabel/python-sdk/15)
<!-- Reviewable:end -->
