### PR TITLE
Do not automatically create relationship types

### DIFF
--- a/exabel_data_sdk/scripts/create_relationship_type.py
+++ b/exabel_data_sdk/scripts/create_relationship_type.py
@@ -23,15 +23,25 @@ class CreateRelationshipType(BaseScript):
         )
         self.parser.add_argument(
             "--description",
-            required=True,
+            required=False,
             type=str,
             help="One or more paragraphs of text description",
         )
-        self.parser.add_argument(
+        is_ownership_group = self.parser.add_mutually_exclusive_group(required=True)
+        is_ownership_group.add_argument(
             "--is-ownership",
+            default=None,
             required=False,
             action="store_true",
             help="Whether this relationship type is a data set ownership",
+        )
+        is_ownership_group.add_argument(
+            "--no-is-ownership",
+            dest="is_ownership",
+            default=None,
+            required=False,
+            action="store_false",
+            help="Whether this relationship type is not a data set ownership",
         )
 
     def run_script(self, client: ExabelClient, args: argparse.Namespace) -> None:

--- a/exabel_data_sdk/scripts/load_relationships_from_csv.py
+++ b/exabel_data_sdk/scripts/load_relationships_from_csv.py
@@ -43,7 +43,7 @@ class LoadRelationshipsFromCsv(CsvScriptWithEntityMapping):
             "--relationship-type",
             required=True,
             type=str,
-            help="The type of the relationships to be loaded. Created if it doesn't already exist.",
+            help="The type of the relationships to be loaded.",
         )
         self.parser.add_argument(
             "--entity-from-column",

--- a/exabel_data_sdk/scripts/update_relationship_type.py
+++ b/exabel_data_sdk/scripts/update_relationship_type.py
@@ -45,32 +45,26 @@ class UpdateRelationshipType(BaseScript):
         )
         is_ownership_group.add_argument(
             "--no-is-ownership",
+            dest="is_ownership",
             default=None,
             required=False,
-            action="store_true",
+            action="store_false",
             help="Whether this relationship type is not a data set ownership",
         )
 
     def run_script(self, client: ExabelClient, args: argparse.Namespace) -> None:
-        relationship_type = RelationshipType(name=args.name)
         update_mask = []
         if args.description is not None:
-            relationship_type.description = args.description
             update_mask.append("description")
 
         if args.is_ownership is not None:
-            relationship_type.is_ownership = True
-            update_mask.append("is_ownership")
-
-        if args.no_is_ownership is not None:
-            relationship_type.is_ownership = False
             update_mask.append("is_ownership")
 
         relationship_type = client.relationship_api.update_relationship_type(
             RelationshipType(
-                name=relationship_type.name,
-                description=relationship_type.description,
-                is_ownership=relationship_type.is_ownership,
+                name=args.name,
+                description=args.description,
+                is_ownership=args.is_ownership,
             ),
             update_mask=FieldMask(paths=update_mask),
             allow_missing=args.allow_missing,

--- a/exabel_data_sdk/tests/client/api/mock_relationship_api.py
+++ b/exabel_data_sdk/tests/client/api/mock_relationship_api.py
@@ -21,7 +21,7 @@ class MockRelationshipApi(RelationshipApi):
         self._insert_standard_relationship_types()
 
     def _insert_standard_relationship_types(self):
-        for rel_type in ("LOCATED_IN", "WEB_DOMAIN_OWNED_BY"):
+        for rel_type in ("LOCATED_IN", "WEB_DOMAIN_OWNED_BY", "test.HAS_BRAND", "acme.PART_OF"):
             self.types.create(RelationshipType("relationshipTypes/" + rel_type, rel_type, ""))
 
     @staticmethod

--- a/exabel_data_sdk/tests/scripts/common_utils.py
+++ b/exabel_data_sdk/tests/scripts/common_utils.py
@@ -8,7 +8,7 @@ from exabel_data_sdk.tests.client.exabel_mock_client import ExabelMockClient
 def load_test_data_from_csv(
     csv_script: Type[CsvScript], args: Sequence[str], client: ExabelClient = None
 ) -> ExabelClient:
-    """Loads entities to an ExabelMockClient using exabel_data_sdk.scripts.load_entities_from_csv"""
+    """Loads resources to an ExabelMockClient using CsvScript"""
     script = csv_script(args, f"Test{type(csv_script).__name__}")
     client = client or ExabelMockClient()
     script.run_script(client, script.parse_arguments())

--- a/exabel_data_sdk/tests/scripts/test_create_relationship_type.py
+++ b/exabel_data_sdk/tests/scripts/test_create_relationship_type.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest import mock
+
+from exabel_data_sdk import ExabelClient
+from exabel_data_sdk.scripts.create_relationship_type import CreateRelationshipType
+
+common_args = [
+    "script-name",
+    "--api-key",
+    "123",
+    "--name",
+    "relationshipTypes/acme.MY_TEST_RELATIONSHIP",
+]
+
+
+class TestCreateRelationshipType(unittest.TestCase):
+    def test_create_relationship_description_and_ownership(self):
+        args = common_args + [
+            "--description",
+            "My description.",
+            "--is-ownership",
+        ]
+        script = CreateRelationshipType(args, "Create a relationship type.")
+        client = mock.create_autospec(ExabelClient(host="host", api_key="123"))
+        script.run_script(client, script.parse_arguments())
+        call_args_list = client.relationship_api.create_relationship_type.call_args_list
+        self.assertEqual(call_args_list[0][0][0].description, "My description.")
+        self.assertEqual(call_args_list[0][0][0].is_ownership, True)
+
+    def test_create_relationship_no_ownership(self):
+        args = common_args + [
+            "--no-is-ownership",
+        ]
+        script = CreateRelationshipType(args, "Create a relationship type.")
+        client = mock.create_autospec(ExabelClient(host="host", api_key="123"))
+        script.run_script(client, script.parse_arguments())
+        call_args_list = client.relationship_api.create_relationship_type.call_args_list
+        self.assertEqual(call_args_list[0][0][0].description, None)
+        self.assertEqual(call_args_list[0][0][0].is_ownership, False)
+
+    def test_create_relationship_not_specified_ownership(self):
+        args = common_args
+        script = CreateRelationshipType(args, "Create a relationship type.")
+        client = mock.create_autospec(ExabelClient(host="host", api_key="123"))
+        with self.assertRaises(SystemExit):
+            script.run_script(client, script.parse_arguments())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/exabel_data_sdk/tests/scripts/test_load_relationships_from_csv.py
+++ b/exabel_data_sdk/tests/scripts/test_load_relationships_from_csv.py
@@ -2,7 +2,6 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from exabel_data_sdk.client.api.data_classes.relationship import Relationship
-from exabel_data_sdk.client.api.data_classes.relationship_type import RelationshipType
 from exabel_data_sdk.scripts.load_relationships_from_csv import LoadRelationshipsFromCsv
 from exabel_data_sdk.tests.scripts.common_utils import load_test_data_from_csv
 
@@ -30,11 +29,6 @@ class TestLoadRelationships(unittest.TestCase):
             "description",
         ]
         client = load_test_data_from_csv(LoadRelationshipsFromCsv, args)
-        # Check that the relationship type was created
-        self.assertEqual(
-            RelationshipType("relationshipTypes/acme.PART_OF"),
-            client.relationship_api.get_relationship_type("relationshipTypes/acme.PART_OF"),
-        )
         expected_relationships = [
             Relationship(
                 relationship_type="relationshipTypes/acme.PART_OF",
@@ -76,7 +70,7 @@ class TestLoadRelationships(unittest.TestCase):
     def check_relationships(self, client, expected_relationships):
         """Check expected entities against actual entities retrieved from the client"""
         all_relationships = client.relationship_api.list_relationships().results
-        self.assertListEqual(expected_relationships, all_relationships)
+        self.assertCountEqual(expected_relationships, all_relationships)
         for expected_relationship in expected_relationships:
             relationship = client.relationship_api.get_relationship(
                 expected_relationship.relationship_type,
@@ -96,11 +90,6 @@ class TestLoadRelationships(unittest.TestCase):
             "--upsert",
         ]
         client = load_test_data_from_csv(LoadRelationshipsFromCsv, args)
-        # Check that the relationship type was created
-        self.assertEqual(
-            RelationshipType("relationshipTypes/acme.PART_OF"),
-            client.relationship_api.get_relationship_type("relationshipTypes/acme.PART_OF"),
-        )
         expected_relationships = [
             Relationship(
                 relationship_type="relationshipTypes/acme.PART_OF",

--- a/exabel_data_sdk/tests/services/test_csv_relationship_loader.py
+++ b/exabel_data_sdk/tests/services/test_csv_relationship_loader.py
@@ -75,7 +75,7 @@ class TestCsvRelationshipLoader(unittest.TestCase):
             ),
         ]
         actual_relationships = client.relationship_api.list_relationships().results
-        self.assertSequenceEqual(expected_relationships, actual_relationships)
+        self.assertCountEqual(expected_relationships, actual_relationships)
 
     def test_load_relationships_with_non_existent_property(self):
         client: ExabelClient = ExabelMockClient()
@@ -89,3 +89,42 @@ class TestCsvRelationshipLoader(unittest.TestCase):
                 property_columns={"non_existent_prop": str},
                 upsert=False,
             )
+
+    def test_load_relationships_with_non_existent_relationship_type(self):
+        client: ExabelClient = ExabelMockClient()
+        with self.assertRaises(CsvLoadingException):
+            CsvRelationshipLoader(client).load_relationships(
+                filename="exabel_data_sdk/tests/resources/data/relationships.csv",
+                namespace="test",
+                relationship_type="NON_EXISTENT_RELATIONSHIPTYPE",
+                entity_from_column="entity_from",
+                entity_to_column="brand",
+                upsert=False,
+            )
+
+    def test_load_relationships_with_existent_relationship_type(self):
+        client: ExabelClient = ExabelMockClient()
+        CsvRelationshipLoader(client).load_relationships(
+            filename="exabel_data_sdk/tests/resources/data/relationships.csv",
+            namespace="test",
+            relationship_type="HAS_BRAND",
+            entity_from_column="entity_from",
+            entity_to_column="brand",
+            upsert=False,
+        )
+        expected_relationships = [
+            Relationship(
+                relationship_type="relationshipTypes/test.HAS_BRAND",
+                from_entity="entityTypes/company/company_x",
+                to_entity="entityTypes/brand/entities/test.Spring_Vine",
+                read_only=False,
+            ),
+            Relationship(
+                relationship_type="relationshipTypes/test.HAS_BRAND",
+                from_entity="entityTypes/company/company_y",
+                to_entity="entityTypes/brand/entities/test.The_Coconut_Tree",
+                read_only=False,
+            ),
+        ]
+        actual_relationships = client.relationship_api.list_relationships().results
+        self.assertCountEqual(expected_relationships, actual_relationships)


### PR DESCRIPTION
* Also make `--is-ownernship`/`--no-is-ownership` mandatory when creating relationship types.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exabel/python-sdk/74)
<!-- Reviewable:end -->
