### PR TITLE
Fix raised exception when derived signal unit is not set

### DIFF
--- a/exabel_data_sdk/client/api/data_classes/derived_signal.py
+++ b/exabel_data_sdk/client/api/data_classes/derived_signal.py
@@ -36,6 +36,8 @@ class DerivedSignalType(Enum):
 class DerivedSignalUnit(Enum):
     """Enum representing the unit of a derived signal."""
 
+    # The signal has not been assigned a unit.
+    DERIVED_SIGNAL_UNIT_INVALID = ProtoDerivedSignalUnit.DERIVED_SIGNAL_UNIT_INVALID
     # The signal represents normal floating point numbers.
     NUMBER = ProtoDerivedSignalUnit.NUMBER
     # The signal represents a ratio, typically with values in the interval [0, 1].


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exabel/python-sdk/96)
<!-- Reviewable:end -->
