### PR TITLE
Fix silent failures in uploading invalid timeseries

### DIFF
--- a/exabel_data_sdk/client/api/bulk_insert.py
+++ b/exabel_data_sdk/client/api/bulk_insert.py
@@ -3,7 +3,11 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from time import sleep, time
 from typing import Callable, Optional, Sequence
 
-from exabel_data_sdk.client.api.data_classes.request_error import ErrorType, RequestError
+from exabel_data_sdk.client.api.data_classes.request_error import (
+    ErrorType,
+    RequestError,
+    ResourceCreationError,
+)
 from exabel_data_sdk.client.api.resource_creation_result import (
     ResourceCreationResult,
     ResourceCreationResults,
@@ -48,6 +52,12 @@ def _process(
             else ResourceCreationStatus.FAILED
         )
         results.add(ResourceCreationResult(status, resource, error))
+    except TypeError as error:
+        status = ResourceCreationStatus.FAILED
+        resource_creation_error = ResourceCreationError(
+            ErrorType.INVALID_DATA_POINTS, message=str(error)
+        )
+        results.add(ResourceCreationResult(status, resource, resource_creation_error))
 
 
 def _raise_error() -> None:

--- a/exabel_data_sdk/client/api/data_classes/request_error.py
+++ b/exabel_data_sdk/client/api/data_classes/request_error.py
@@ -24,6 +24,8 @@ class ErrorType(Enum):
     UNAVAILABLE = 5
     # Timeout.
     TIMEOUT = 6
+    # Invalid data points
+    INVALID_DATA_POINTS = 7
     # Any internal error.
     INTERNAL = 10
 
@@ -66,3 +68,18 @@ class RequestError(Exception):
     error_type: ErrorType
     message: Optional[str] = None
     precondition_failure: Optional[PreconditionFailure] = None
+
+
+@dataclass
+class ResourceCreationError(Exception):
+    """
+    Represents en error returned from resource creation.
+    A typical reason to this error is sending invalid data in the request.
+
+    Attributes:
+        error_type (ErrorType): Type of error.
+        message(str): Exception message.
+    """
+
+    error_type: ErrorType
+    message: Optional[str] = None

--- a/exabel_data_sdk/client/api/resource_creation_result.py
+++ b/exabel_data_sdk/client/api/resource_creation_result.py
@@ -1,13 +1,16 @@
 import logging
 from collections import Counter
 from enum import Enum
-from typing import Generic, List, Optional, Sequence, TypeVar
+from typing import Generic, List, Optional, Sequence, TypeVar, Union
 
 import pandas as pd
 
 from exabel_data_sdk.client.api.data_classes.entity import Entity
 from exabel_data_sdk.client.api.data_classes.relationship import Relationship
-from exabel_data_sdk.client.api.data_classes.request_error import RequestError
+from exabel_data_sdk.client.api.data_classes.request_error import (
+    RequestError,
+    ResourceCreationError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +41,10 @@ class ResourceCreationResult(Generic[TResource]):
     """
 
     def __init__(
-        self, status: ResourceCreationStatus, resource: TResource, error: RequestError = None
+        self,
+        status: ResourceCreationStatus,
+        resource: TResource,
+        error: Union[RequestError, ResourceCreationError] = None,
     ):
         self.status = status
         self.resource: TResource = resource


### PR DESCRIPTION
update SDK according to monorepo's PR: DEV-58 Python SDK: Fix silent failures in uploading invalid timeseries (#9062)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exabel/python-sdk/114)
<!-- Reviewable:end -->
