### PR TITLE
Include location in csv file and statistics in error message

### DIFF
--- a/exabel_data_sdk/services/csv_time_series_loader.py
+++ b/exabel_data_sdk/services/csv_time_series_loader.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 import pandas as pd
 from dateutil import tz
@@ -25,6 +25,7 @@ from exabel_data_sdk.util.resource_name_normalization import (
 )
 
 logger = logging.getLogger(__name__)
+
 
 # pylint: disable=unsubscriptable-object
 
@@ -147,30 +148,7 @@ class CsvTimeSeriesLoader:
             entity_mapping=entity_mapping,
         )
         ts_data.rename(columns={ts_data.columns[0]: "entity"}, inplace=True)
-
-        # validate all data points are numeric
-        columns_with_invalid_data_points = {}
-        for col in signal_columns:
-            if not is_numeric_dtype(ts_data[col]):
-                examples = {
-                    index: ts_data[col][index]
-                    for index in ts_data[col][~ts_data[col].str.isnumeric()][:5].index
-                }
-                columns_with_invalid_data_points[col] = examples
-
-        if columns_with_invalid_data_points:
-            error_message = (
-                "Signal column(s) contain non-numeric values. Please ensure all values "
-                "can be parsed to numeric values.\n"
-            )
-            error_message += "Columns with non-numeric values (with up to 5 examples):"
-            for col, examples in columns_with_invalid_data_points.items():
-                pretty_examples = ", ".join(
-                    f"'{value}' at index {index}" for index, value in examples.items()
-                )
-                error_message += f"  {col}: {pretty_examples}"
-            raise CsvLoadingException(error_message)
-
+        self.validate_numeric(ts_data, signal_columns)
         logger.info("Loading signals %s ...", ", ".join(str(s) for s in signals))
 
         # validate signal names
@@ -322,3 +300,48 @@ class CsvTimeSeriesLoader:
         else:
             ts_data.set_index(date_index, inplace=True)
             ts_data.drop(columns="date", inplace=True)
+
+    @staticmethod
+    def validate_numeric(ts_data: pd.DataFrame, signal_columns: list) -> None:
+        """
+        To check signal values of csv file.
+        Detect non-numeric values and prepare error message containing examples
+        """
+        non_numeric_columns: Dict[str, pd.DataFrame] = {}
+
+        def is_float(element: Any) -> bool:
+            try:
+                float(element)
+                return True
+            except ValueError:
+                return False
+
+        def base_columns(time_series: pd.DataFrame) -> Sequence[str]:
+            return (
+                ["entity", "date", "known_time"]
+                if "known_time" in time_series.columns
+                else ["entity", "date"]
+            )
+
+        def extract_entity_name(element: str) -> str:
+            return element.split("/entities/")[-1].split(".")[-1]
+
+        for column in signal_columns:
+            if not is_numeric_dtype(ts_data[column]) and any(~ts_data[column].apply(is_float)):
+                non_numeric_columns[column] = ts_data.loc[
+                    ~ts_data[column].apply(is_float), [*base_columns(ts_data), column]
+                ]
+        if len(non_numeric_columns) > 0:
+            error_message = (
+                f"{len(non_numeric_columns)} signal column(s) contain non-numeric values. Please "
+                f"ensure all values can be parsed to numeric values\n"
+            )
+            for column, df in non_numeric_columns.items():
+                df["entity"] = df["entity"].apply(extract_entity_name)
+                error_message = (
+                    f"{error_message}\n\n"
+                    f"Signal '{column}' contains {df.shape[0]} non-numeric values"
+                    f"{', check the first five as examples' if df.shape[0] > 5 else ''}:"
+                    f"\n{df.iloc[:5].to_string(index=False)}"
+                )
+            raise CsvLoadingException(error_message)

--- a/exabel_data_sdk/tests/resources/data/time_series_with_non_numeric_values.csv
+++ b/exabel_data_sdk/tests/resources/data/time_series_with_non_numeric_values.csv
@@ -1,0 +1,14 @@
+brand,date,known_time,production,price
+big_brand,2022-01-01,2022-01-01,1500,13
+big_brand,2022-01-01,2022-01-15,1540,14
+middle_brand,2022-02-01,2022-02-01,1543,fifteen
+middle_brand,2022-01-01,2022-01-01,2400,sixteen
+middle_brand,2022-01-02,2022-01-10,2400,29.1
+small_brand,2022-02-01,2022-02-01,three_thousands,29.1
+small_brand,2022-02-02,2022-02-03,3001,seventeen
+small_brand,2022-02-04,2022-02-05,four_thousands,29.1
+mini_brand,2022-02-05,2022-02-06,five_thousands,29.1
+mini_brand,2022-02-06,2022-02-07,six_thousands,29.1
+mini_brand,2022-02-07,2022-02-08,seven_thousands,29.1
+mini_brand,2022-03-01,2022-03-02,7001,29.1
+mini_brand,2022-03-02,2022-03-04,nine_thousands,29.1

--- a/exabel_data_sdk/tests/services/test_csv_time_series_loader.py
+++ b/exabel_data_sdk/tests/services/test_csv_time_series_loader.py
@@ -16,20 +16,14 @@ class TestCsvTimeSeriesLoader(unittest.TestCase):
                 namespace="test",
             )
         exception = context.exception
-        expected_error_message_beginning = (
+        actual = str(exception)
+        self.assertIn(
             "2 signal column(s) contain non-numeric values. "
-            "Please ensure all values can be parsed to numeric values\n\n\n"
-            "Signal 'production' contains 6 non-numeric values, check the first five as examples:\n"
-            "     entity       date known_time      production\n"
-            "small_brand 2022-02-01 2022-02-01 three_thousands\n"
-            "small_brand 2022-02-04 2022-02-05  four_thousands\n "
-            "mini_brand 2022-02-05 2022-02-06  five_thousands\n "
-            "mini_brand 2022-02-06 2022-02-07   six_thousands\n "
-            "mini_brand 2022-02-07 2022-02-08 seven_thousands\n\n"
-            "Signal 'price' contains 3 non-numeric values:\n      "
-            "entity       date known_time     price\n"
-            "middle_brand 2022-02-01 2022-02-01   fifteen\n"
-            "middle_brand 2022-01-01 2022-01-01   sixteen\n "
-            "small_brand 2022-02-02 2022-02-03 seventeen"
+            "Please ensure all values can be parsed to numeric values",
+            actual,
         )
-        self.assertEqual(expected_error_message_beginning, str(exception))
+        self.assertIn(
+            "Signal 'production' contains 6 non-numeric values, check the first five as examples:",
+            actual,
+        )
+        self.assertIn("Signal 'price' contains 3 non-numeric values", actual)

--- a/exabel_data_sdk/tests/services/test_csv_time_series_loader.py
+++ b/exabel_data_sdk/tests/services/test_csv_time_series_loader.py
@@ -1,0 +1,35 @@
+import unittest
+
+from exabel_data_sdk import ExabelClient
+from exabel_data_sdk.services.csv_exception import CsvLoadingException
+from exabel_data_sdk.services.csv_time_series_loader import CsvTimeSeriesLoader
+from exabel_data_sdk.tests.client.exabel_mock_client import ExabelMockClient
+
+
+class TestCsvTimeSeriesLoader(unittest.TestCase):
+    def test_read_csv_should_failed_by_non_numeric_signal_values(self):
+        client: ExabelClient = ExabelMockClient()
+        with self.assertRaises(CsvLoadingException) as context:
+            CsvTimeSeriesLoader(client).load_time_series(
+                filename="exabel_data_sdk/tests/resources/"
+                "data/time_series_with_non_numeric_values.csv",
+                namespace="test",
+            )
+        exception = context.exception
+        expected_error_message_beginning = (
+            "2 signal column(s) contain non-numeric values. "
+            "Please ensure all values can be parsed to numeric values\n\n\n"
+            "Signal 'production' contains 6 non-numeric values, check the first five as examples:\n"
+            "     entity       date known_time      production\n"
+            "small_brand 2022-02-01 2022-02-01 three_thousands\n"
+            "small_brand 2022-02-04 2022-02-05  four_thousands\n "
+            "mini_brand 2022-02-05 2022-02-06  five_thousands\n "
+            "mini_brand 2022-02-06 2022-02-07   six_thousands\n "
+            "mini_brand 2022-02-07 2022-02-08 seven_thousands\n\n"
+            "Signal 'price' contains 3 non-numeric values:\n      "
+            "entity       date known_time     price\n"
+            "middle_brand 2022-02-01 2022-02-01   fifteen\n"
+            "middle_brand 2022-01-01 2022-01-01   sixteen\n "
+            "small_brand 2022-02-02 2022-02-03 seventeen"
+        )
+        self.assertEqual(expected_error_message_beginning, str(exception))


### PR DESCRIPTION
This PR combine two commits to master branch of monorepo:

1. DEV-988 Python SDK: Include location in CSV file and statistics in error message (https://github.com/Exabel/exabel/pull/9099)
2. Make unittest work on both monorepo and sdk repo (https://github.com/Exabel/exabel/pull/9114)
 
The second was to adjusted assertion in unit test. Because the first PR's code can not be accepted by Jenkins in this repo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exabel/python-sdk/116)
<!-- Reviewable:end -->
