### PR TITLE
revert hard fail on duplicate company identifiers in entity mapping

### DIFF
--- a/exabel_data_sdk/scripts/delete_relationship.py
+++ b/exabel_data_sdk/scripts/delete_relationship.py
@@ -8,7 +8,7 @@ from exabel_data_sdk.scripts.base_script import BaseScript
 
 class DeleteRelationship(BaseScript):
     """
-    Deletes a new relationship.
+    Deletes an existing relationship.
     """
 
     def __init__(self, argv: Sequence[str], description: str):
@@ -31,12 +31,6 @@ class DeleteRelationship(BaseScript):
             required=True,
             type=str,
             help="The resource name of the entity the relationship goes to",
-        )
-        self.parser.add_argument(
-            "--description",
-            required=True,
-            type=str,
-            help="One or more paragraphs of text description",
         )
 
     def run_script(self, client: ExabelClient, args: argparse.Namespace) -> None:

--- a/exabel_data_sdk/tests/util/test_resource_name_normalization.py
+++ b/exabel_data_sdk/tests/util/test_resource_name_normalization.py
@@ -289,9 +289,7 @@ class TestResourceNameNormalization(unittest.TestCase):
         good_mapping = {"Abc!": "Abc_1", "Abcd": "Abcd", "Abc?": "Abc_2"}
         _assert_no_collision(good_mapping)
 
-    def test_mapping_with_duplicated_entity_identifiers_should_fail(self):
-        company_data = pd.Series(["TGT US", "TGT UK"], name="bloomberg_ticker")
-
+    def test_mapping_with_duplicated_entity_identifiers_should_not_fail(self):
         search_terms = [
             SearchTerm(field="bloomberg_ticker", query="TGT US"),
             SearchTerm(field="bloomberg_ticker", query="TGT UK"),
@@ -311,6 +309,3 @@ class TestResourceNameNormalization(unittest.TestCase):
                 ],
             ),
         ]
-        with self.assertRaises(ValueError) as context:
-            to_entity_resource_names(entity_api, company_data, namespace="acme")
-        self.assertEqual("Resource name collisions detected", str(context.exception))

--- a/exabel_data_sdk/util/resource_name_normalization.py
+++ b/exabel_data_sdk/util/resource_name_normalization.py
@@ -260,7 +260,7 @@ def to_entity_resource_names(
                 if identifier
             }
         )
-    _assert_no_collision(mapping)
+        _assert_no_collision(mapping)
 
     result = identifiers.map(mapping)
     result.name = "entity"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exabel/python-sdk/118)
<!-- Reviewable:end -->
