### PR TITLE
Allow manual runs of workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Build, test and publish Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build-package:

--- a/.github/workflows/test_installability.yml
+++ b/.github/workflows/test_installability.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Run on Fridays at 05:00 UTC
     - cron: '0 5 * * 5'
+  workflow_dispatch:
 
 jobs:
   test-package:


### PR DESCRIPTION
Allow manual trigger, should be correct syntax even though it looks weird: https://github.com/orgs/community/discussions/26098

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exabel/python-sdk/131)
<!-- Reviewable:end -->
