### PR TITLE
Fix paging iterator bug

### DIFF
--- a/exabel_data_sdk/client/api/pageable_resource.py
+++ b/exabel_data_sdk/client/api/pageable_resource.py
@@ -28,6 +28,7 @@ class PageableResourceMixin:
     @staticmethod
     def _get_resource_iterator(
         pageable_func: Callable[..., PagingResult[PageableResourceT]],
+        page_size: int = 1000,
         **kwargs: str,
     ) -> Iterator[PageableResourceT]:
         """
@@ -35,11 +36,9 @@ class PageableResourceMixin:
         results.
         """
         page_token: Optional[str] = None
-        resource_count = 0
         while True:
-            result = pageable_func(**kwargs, page_token=page_token)
+            result = pageable_func(**kwargs, page_token=page_token, page_size=page_size)
             yield from result.results
             page_token = result.next_page_token
-            resource_count += len(result.results)
-            if resource_count >= result.total_size:
+            if len(result.results) < page_size:
                 break

--- a/exabel_data_sdk/tests/client/api/test_entity_api.py
+++ b/exabel_data_sdk/tests/client/api/test_entity_api.py
@@ -41,46 +41,40 @@ class TestEntityApi(unittest.TestCase):
 
     def test_get_entity_type_iterator(self):
         entity_api = EntityApi(ClientConfig("api-key"))
-        entity_type_1 = mock.create_autospec(EntityType)
-        entity_type_2 = mock.create_autospec(EntityType)
-        entity_type_3 = mock.create_autospec(EntityType)
+        entity_type = mock.create_autospec(EntityType)
         entity_api.list_entity_types = mock.MagicMock()
         entity_api.list_entity_types.side_effect = [
-            PagingResult([entity_type_1], next_page_token="1", total_size=3),
-            PagingResult([entity_type_2], next_page_token="2", total_size=3),
-            PagingResult([entity_type_3], next_page_token=None, total_size=3),
+            PagingResult([entity_type] * 1000, next_page_token="1000", total_size=2555),
+            PagingResult([entity_type] * 1000, next_page_token="2000", total_size=2555),
+            PagingResult([entity_type] * 555, next_page_token="~~~", total_size=2555),
             AssertionError("Should not be called"),
         ]
         entity_types = list(entity_api.get_entity_type_iterator())
-        self.assertEqual(3, len(entity_types))
-        self.assertSequenceEqual([entity_type_1, entity_type_2, entity_type_3], entity_types)
+        self.assertEqual(2555, len(entity_types))
+        self.assertSequenceEqual([entity_type] * 2555, entity_types)
         entity_api.list_entity_types.assert_has_calls(
             [
-                mock.call(page_token=None),
-                mock.call(page_token="1"),
-                mock.call(page_token="2"),
+                mock.call(page_token=None, page_size=1000),
+                mock.call(page_token="1000", page_size=1000),
+                mock.call(page_token="2000", page_size=1000),
             ]
         )
 
     def test_get_entities_iterator(self):
         entity_api = EntityApi(ClientConfig("api-key"))
-        entity_1 = mock.create_autospec(Entity)
-        entity_2 = mock.create_autospec(Entity)
-        entity_3 = mock.create_autospec(Entity)
+        entity = mock.create_autospec(Entity)
         entity_api.list_entities = mock.MagicMock()
         entity_api.list_entities.side_effect = [
-            PagingResult([entity_1], next_page_token="1", total_size=3),
-            PagingResult([entity_2], next_page_token="2", total_size=3),
-            PagingResult([entity_3], next_page_token=None, total_size=3),
+            PagingResult([entity] * 1000, next_page_token="1000", total_size=1100),
+            PagingResult([entity] * 100, next_page_token="~~~", total_size=1100),
             AssertionError("Should not be called"),
         ]
         entities = list(entity_api.get_entities_iterator("entity_type"))
-        self.assertEqual(3, len(entities))
-        self.assertSequenceEqual([entity_1, entity_2, entity_3], entities)
+        self.assertEqual(1100, len(entities))
+        self.assertSequenceEqual([entity] * 1100, entities)
         entity_api.list_entities.assert_has_calls(
             [
-                mock.call(entity_type="entity_type", page_token=None),
-                mock.call(entity_type="entity_type", page_token="1"),
-                mock.call(entity_type="entity_type", page_token="2"),
+                mock.call(entity_type="entity_type", page_token=None, page_size=1000),
+                mock.call(entity_type="entity_type", page_token="1000", page_size=1000),
             ]
         )

--- a/exabel_data_sdk/tests/client/api/test_pageable_resource.py
+++ b/exabel_data_sdk/tests/client/api/test_pageable_resource.py
@@ -6,25 +6,44 @@ from exabel_data_sdk.client.api.pageable_resource import PageableResourceMixin
 
 
 class _PageableApiMock(PageableResourceMixin):
-    def __init__(self, resources: Sequence[str]):
+    def __init__(self, resources: Sequence[str], total_sizes: Optional[Sequence[int]] = None):
         self.resources = resources
+        if total_sizes is not None:
+            self.total_sizes = total_sizes
+        else:
+            self.total_sizes = [len(resources)] * len(resources)
 
-    def get_resource_page(self, page_token: Optional[str] = None) -> PagingResult[str]:
+    def get_resource_page(
+        self, page_size: Optional[int] = None, page_token: Optional[str] = None
+    ) -> PagingResult[str]:
         """Return a page of resources."""
-        page_idx = int(page_token) if page_token else 0
+        assert page_size == 1
+        if page_token == "~~~":
+            page_idx = len(self.resources)
+        else:
+            page_idx = int(page_token) if page_token else 0
+        if page_idx >= len(self.resources):
+            return PagingResult([], next_page_token="~~~", total_size=self.total_sizes[-1])
         return PagingResult(
-            self.resources[page_idx],
+            [self.resources[page_idx]] if page_idx < len(self.resources) else [],
             next_page_token=str(page_idx + 1),
-            total_size=len(self.resources),
+            total_size=self.total_sizes[page_idx],
         )
 
     def get_resource_iterator(self) -> Iterator[str]:
         """Return an iterator with all resources."""
-        return self._get_resource_iterator(self.get_resource_page)
+        return self._get_resource_iterator(self.get_resource_page, page_size=1)
 
 
 class TestPageableResourceMixin(unittest.TestCase):
     def test_get_resource_iterator(self):
         resources = ["a", "b", "c"]
         api = _PageableApiMock(resources)
+        self.assertListEqual(list(api.get_resource_iterator()), resources)
+
+    def test_get_resource_iterator__with_varying_total_sizes(self):
+        """Avoid infinite iteration if the item set is modified while iterating."""
+        resources = ["a", "b", "c"]
+        total_sizes = [3, 4, 4]
+        api = _PageableApiMock(resources, total_sizes)
         self.assertListEqual(list(api.get_resource_iterator()), resources)

--- a/exabel_data_sdk/tests/client/api/test_relationship_api.py
+++ b/exabel_data_sdk/tests/client/api/test_relationship_api.py
@@ -49,85 +49,81 @@ class TestRelationshipApi(unittest.TestCase):
 
     def test_get_relationships_from_entity_iterator(self):
         relationship_api = RelationshipApi(ClientConfig("api-key"))
-        relationship_1 = mock.create_autospec(Relationship)
-        relationship_2 = mock.create_autospec(Relationship)
-        relationship_3 = mock.create_autospec(Relationship)
+        relationship = mock.create_autospec(Relationship)
         relationship_api.get_relationships_from_entity = mock.MagicMock()
         relationship_api.get_relationships_from_entity.side_effect = [
-            PagingResult([relationship_1], next_page_token="1", total_size=3),
-            PagingResult([relationship_2], next_page_token="2", total_size=3),
-            PagingResult([relationship_3], next_page_token=None, total_size=3),
+            PagingResult([relationship] * 1000, next_page_token="1000", total_size=1100),
+            PagingResult([relationship] * 100, next_page_token="~~~", total_size=1100),
             AssertionError("Should not be called"),
         ]
         relationships = list(
             relationship_api.get_relationships_from_entity_iterator("relationship_type", "entity")
         )
-        self.assertEqual(3, len(relationships))
-        self.assertSequenceEqual([relationship_1, relationship_2, relationship_3], relationships)
+        self.assertEqual(1100, len(relationships))
+        self.assertSequenceEqual([relationship] * 1100, relationships)
         relationship_api.get_relationships_from_entity.assert_has_calls(
             [
                 mock.call(
-                    relationship_type="relationship_type", from_entity="entity", page_token=None
+                    relationship_type="relationship_type",
+                    from_entity="entity",
+                    page_token=None,
+                    page_size=1000,
                 ),
                 mock.call(
-                    relationship_type="relationship_type", from_entity="entity", page_token="1"
-                ),
-                mock.call(
-                    relationship_type="relationship_type", from_entity="entity", page_token="2"
+                    relationship_type="relationship_type",
+                    from_entity="entity",
+                    page_token="1000",
+                    page_size=1000,
                 ),
             ]
         )
 
     def test_get_relationships_to_entity_iterator(self):
         relationship_api = RelationshipApi(ClientConfig("api-key"))
-        relationship_1 = mock.create_autospec(Relationship)
-        relationship_2 = mock.create_autospec(Relationship)
-        relationship_3 = mock.create_autospec(Relationship)
+        relationship = mock.create_autospec(Relationship)
         relationship_api.get_relationships_to_entity = mock.MagicMock()
         relationship_api.get_relationships_to_entity.side_effect = [
-            PagingResult([relationship_1], next_page_token="1", total_size=3),
-            PagingResult([relationship_2], next_page_token="2", total_size=3),
-            PagingResult([relationship_3], next_page_token=None, total_size=3),
+            PagingResult([relationship] * 1000, next_page_token="1000", total_size=1100),
+            PagingResult([relationship] * 100, next_page_token="~~~", total_size=1100),
             AssertionError("Should not be called"),
         ]
         relationships = list(
             relationship_api.get_relationships_to_entity_iterator("relationship_type", "entity")
         )
-        self.assertEqual(3, len(relationships))
-        self.assertSequenceEqual([relationship_1, relationship_2, relationship_3], relationships)
+        self.assertEqual(1100, len(relationships))
+        self.assertSequenceEqual([relationship] * 1100, relationships)
         relationship_api.get_relationships_to_entity.assert_has_calls(
             [
                 mock.call(
-                    relationship_type="relationship_type", to_entity="entity", page_token=None
+                    relationship_type="relationship_type",
+                    to_entity="entity",
+                    page_token=None,
+                    page_size=1000,
                 ),
                 mock.call(
-                    relationship_type="relationship_type", to_entity="entity", page_token="1"
-                ),
-                mock.call(
-                    relationship_type="relationship_type", to_entity="entity", page_token="2"
+                    relationship_type="relationship_type",
+                    to_entity="entity",
+                    page_token="1000",
+                    page_size=1000,
                 ),
             ]
         )
 
     def test_get_relationships_iterator(self):
         relationship_api = RelationshipApi(ClientConfig("api-key"))
-        relationship_1 = mock.create_autospec(Relationship)
-        relationship_2 = mock.create_autospec(Relationship)
-        relationship_3 = mock.create_autospec(Relationship)
+        relationship = mock.create_autospec(Relationship)
         relationship_api.list_relationships = mock.MagicMock()
         relationship_api.list_relationships.side_effect = [
-            PagingResult([relationship_1], next_page_token="1", total_size=3),
-            PagingResult([relationship_2], next_page_token="2", total_size=3),
-            PagingResult([relationship_3], next_page_token=None, total_size=3),
+            PagingResult([relationship] * 1000, next_page_token="1000", total_size=1100),
+            PagingResult([relationship] * 100, next_page_token="~~~", total_size=1100),
             AssertionError("Should not be called"),
         ]
         relationships = list(relationship_api.get_relationships_iterator("relationship_type"))
-        self.assertEqual(3, len(relationships))
-        self.assertSequenceEqual([relationship_1, relationship_2, relationship_3], relationships)
+        self.assertEqual(1100, len(relationships))
+        self.assertSequenceEqual([relationship] * 1100, relationships)
         relationship_api.list_relationships.assert_has_calls(
             [
                 mock.call(relationship_type="relationship_type", page_token=None, page_size=1000),
-                mock.call(relationship_type="relationship_type", page_token="1", page_size=1000),
-                mock.call(relationship_type="relationship_type", page_token="2", page_size=1000),
+                mock.call(relationship_type="relationship_type", page_token="1000", page_size=1000),
             ]
         )

--- a/exabel_data_sdk/tests/client/api/test_signal_api.py
+++ b/exabel_data_sdk/tests/client/api/test_signal_api.py
@@ -10,23 +10,19 @@ from exabel_data_sdk.client.client_config import ClientConfig
 class TestSignalApi(unittest.TestCase):
     def test_get_signal_iterator(self):
         signal_api = SignalApi(ClientConfig("api-key"))
-        signal_1 = mock.create_autospec(Signal)
-        signal_2 = mock.create_autospec(Signal)
-        signal_3 = mock.create_autospec(Signal)
+        signal = mock.create_autospec(Signal)
         signal_api.list_signals = mock.MagicMock()
         signal_api.list_signals.side_effect = [
-            PagingResult([signal_1], next_page_token="1", total_size=3),
-            PagingResult([signal_2], next_page_token="2", total_size=3),
-            PagingResult([signal_3], next_page_token=None, total_size=3),
+            PagingResult([signal] * 1000, next_page_token="1000", total_size=1100),
+            PagingResult([signal] * 100, next_page_token="~~~", total_size=1100),
             AssertionError("Should not be called"),
         ]
         signals = list(signal_api.get_signal_iterator())
-        self.assertEqual(3, len(signals))
-        self.assertSequenceEqual([signal_1, signal_2, signal_3], signals)
+        self.assertEqual(1100, len(signals))
+        self.assertSequenceEqual([signal] * 1100, signals)
         signal_api.list_signals.assert_has_calls(
             [
-                mock.call(page_token=None),
-                mock.call(page_token="1"),
-                mock.call(page_token="2"),
+                mock.call(page_token=None, page_size=1000),
+                mock.call(page_token="1000", page_size=1000),
             ]
         )

--- a/exabel_data_sdk/tests/client/api/test_time_series_api.py
+++ b/exabel_data_sdk/tests/client/api/test_time_series_api.py
@@ -178,46 +178,40 @@ class TestTimeSeriesApi(unittest.TestCase):
 
     def test_get_signal_time_series_iterator(self):
         ts_api = TimeSeriesApi(ClientConfig("api-key"))
-        ts_1 = "ts_1"
-        ts_2 = "ts_2"
-        ts_3 = "ts_3"
         ts_api.get_signal_time_series = mock.MagicMock()
         ts_api.get_signal_time_series.side_effect = [
-            PagingResult([ts_1], next_page_token="1", total_size=3),
-            PagingResult([ts_2], next_page_token="2", total_size=3),
-            PagingResult([ts_3], next_page_token=None, total_size=3),
+            PagingResult([f"ts_{i}" for i in range(1000)], next_page_token="1000", total_size=1100),
+            PagingResult(
+                [f"ts_{i}" for i in range(1000, 1100)], next_page_token="1000", total_size=1100
+            ),
             AssertionError("Should not be called"),
         ]
         ts = list(ts_api.get_signal_time_series_iterator("signal"))
-        self.assertEqual(3, len(ts))
-        self.assertSequenceEqual([ts_1, ts_2, ts_3], ts)
+        self.assertEqual(1100, len(ts))
+        self.assertSequenceEqual([f"ts_{i}" for i in range(1100)], ts)
         ts_api.get_signal_time_series.assert_has_calls(
             [
-                mock.call(signal="signal", page_token=None),
-                mock.call(signal="signal", page_token="1"),
-                mock.call(signal="signal", page_token="2"),
+                mock.call(signal="signal", page_token=None, page_size=1000),
+                mock.call(signal="signal", page_token="1000", page_size=1000),
             ]
         )
 
     def test_get_entity_time_series_iterator(self):
         ts_api = TimeSeriesApi(ClientConfig("api-key"))
-        ts_1 = "ts_1"
-        ts_2 = "ts_2"
-        ts_3 = "ts_3"
         ts_api.get_entity_time_series = mock.MagicMock()
         ts_api.get_entity_time_series.side_effect = [
-            PagingResult([ts_1], next_page_token="1", total_size=3),
-            PagingResult([ts_2], next_page_token="2", total_size=3),
-            PagingResult([ts_3], next_page_token=None, total_size=3),
+            PagingResult([f"ts_{i}" for i in range(1000)], next_page_token="1000", total_size=1100),
+            PagingResult(
+                [f"ts_{i}" for i in range(1000, 1100)], next_page_token="1000", total_size=1100
+            ),
             AssertionError("Should not be called"),
         ]
         ts = list(ts_api.get_entity_time_series_iterator("entity"))
-        self.assertEqual(3, len(ts))
-        self.assertSequenceEqual([ts_1, ts_2, ts_3], ts)
+        self.assertEqual(1100, len(ts))
+        self.assertSequenceEqual([f"ts_{i}" for i in range(1100)], ts)
         ts_api.get_entity_time_series.assert_has_calls(
             [
-                mock.call(entity="entity", page_token=None),
-                mock.call(entity="entity", page_token="1"),
-                mock.call(entity="entity", page_token="2"),
+                mock.call(entity="entity", page_token=None, page_size=1000),
+                mock.call(entity="entity", page_token="1000", page_size=1000),
             ]
         )


### PR DESCRIPTION
The bug could cause the SDK to end up in an infinite loop if new items were added while iterating over the set of items.