### PR TITLE
Add context7.json to claim library on Context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/exabel/python-sdk",
+  "public_key": "pk_IZAfWleB8DsrwzvKFL99e"
+}


### PR DESCRIPTION
## Summary

- Adds `context7.json` to the repo root to claim and verify ownership of the Exabel Python SDK on [Context7](https://context7.com/exabel/python-sdk)
- Once merged, go to the Context7 claiming modal and click **"Claim Library"** to complete verification

## What is Context7?

Context7 indexes library docs and surfaces them to AI coding assistants via MCP. Claiming the library unlocks an admin panel for managing indexed versions, team access, and refresh rate limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)