### PR TITLE
chore(release): 8.2.0

### DIFF
--- a/exabel/client/api/export_api.py
+++ b/exabel/client/api/export_api.py
@@ -1,6 +1,8 @@
+import io
 import json
 import logging
 import pickle
+import warnings
 from time import time
 from typing import Sequence
 
@@ -16,8 +18,43 @@ from exabel.query.predicate import Predicate
 from exabel.query.query import Query
 from exabel.query.signals import Signals
 from exabel.scripts.utils import conditional_progress_bar
+from exabel.util.handle_missing_imports import handle_missing_imports
 
 logger = logging.getLogger(__name__)
+
+_PICKLE_DEPRECATED_MESSAGE = (
+    "{parameter}='pickle' is deprecated and will be removed in a future release. "
+    "Use 'parquet' (default), 'feather', 'csv', or 'json' instead."
+)
+
+_MULTI_TS_METADATA_KEY = b"exabel_multi_ts_signals"
+
+
+def _read_v2_parquet(content: bytes) -> tuple[pd.DataFrame, frozenset[str]]:
+    """Read a v2 parquet response and extract the multi-ts signal set.
+
+    The server emits ``exabel_multi_ts_signals`` (UTF-8 JSON list of labels)
+    into the parquet schema metadata — always present, empty list when no
+    multi-ts signals participated. A missing key indicates a contract
+    violation (e.g. an unexpected non-server parquet).
+    """
+    with handle_missing_imports(
+        warning=(
+            "'pyarrow' must be installed to use the v2 export endpoints. "
+            "Install it with: pip install 'exabel[export]'"
+        ),
+        reraise=True,
+    ):
+        import pyarrow.parquet as pq
+
+    table = pq.read_table(io.BytesIO(content))
+    raw = (table.schema.metadata or {}).get(_MULTI_TS_METADATA_KEY)
+    if raw is None:
+        raise ValueError(
+            f"Parquet response is missing the {_MULTI_TS_METADATA_KEY.decode()!r} schema "
+            "metadata key — server did not emit a v2-compatible response."
+        )
+    return table.to_pandas(), frozenset(json.loads(raw.decode("utf-8")))
 
 
 class ExportApi:
@@ -56,11 +93,29 @@ class ExportApi:
         file_format is one of:
          * csv
          * excel (.xlsx format)
-         * pickle (pickled pandas DataFrame)
+         * pickle (pickled pandas DataFrame  - deprecated — to be removed)
          * json
          * feather
          * parquet
         """
+        if file_format.lower() == "pickle":
+            warnings.warn(
+                _PICKLE_DEPRECATED_MESSAGE.format(parameter="file_format"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            file_format = "pickle"
+        return self._run_query_bytes(query, file_format)
+
+    def run_query(self, query: str | Query) -> pd.DataFrame:
+        """
+        Run an export data query, and returns a DataFrame with the results.
+        Raises an exception if the status code is not 200.
+        """
+        content = self._run_query_bytes(query, file_format="pickle")
+        return pickle.loads(content)
+
+    def _run_query_bytes(self, query: str | Query, file_format: str) -> bytes:
         if isinstance(query, Query):
             query = query.sql()
         data = {"format": file_format, "query": query}
@@ -83,16 +138,6 @@ class ExportApi:
             error_message = error_message[1:-1]
         error_message = f"Got {response.status_code}: {error_message} for query {query}"
         raise ValueError(error_message)
-
-    def run_query(self, query: str | Query) -> pd.DataFrame:
-        """
-        Run an export data query, and returns a DataFrame with the results.
-        Raises an exception if the status code is not 200.
-        """
-        content = self.run_query_bytes(query, file_format="pickle")
-        content = pickle.loads(content)
-        assert isinstance(content, pd.DataFrame)
-        return content
 
     @staticmethod
     def _to_column(item: str | Column | DerivedSignal) -> str | Column:
@@ -148,12 +193,17 @@ class ExportApi:
         start_time: str | pd.Timestamp | None = None,
         end_time: str | pd.Timestamp | None = None,
         version: str | pd.Timestamp | None = None,
-        output_format: str = "pickle",
+        output_format: str = "parquet",
     ) -> bytes:
         """POST a structured JSON request to the v2 export signals endpoint.
 
         Returns the raw response bytes in the requested format.
         """
+        if output_format.lower() == "pickle":
+            raise ValueError(
+                "pickle is not supported on the v2 export endpoint; "
+                "use parquet, feather, csv, excel, or json"
+            )
         body: dict = {
             "signals": signals,
             "outputFormat": output_format,
@@ -174,13 +224,13 @@ class ExportApi:
 
         url = f"https://{self._backend}/v2/export/signals"
         start = time()
-        logger.info("Sending v2 signal query: %s", body)
+        logger.info("Sending v2 signal export request: %s", body)
         response = self._session.post(
             url, data=json.dumps(body), headers={"Content-Type": "application/json"}, timeout=600
         )
         spent_time = time() - start
         logger.info(
-            "v2 query completed in %.1f seconds, received %d bytes, status %d",
+            "v2 export completed in %.1f seconds, received %d bytes, status %d",
             spent_time,
             len(response.content),
             response.status_code,
@@ -192,7 +242,7 @@ class ExportApi:
             error_message = error_message[1:-1]
         raise ValueError(f"Got {response.status_code}: {error_message}")
 
-    def run_signal_query_v2(
+    def run_export_signals_v2(
         self,
         signals: list[dict[str, str]],
         *,
@@ -202,22 +252,25 @@ class ExportApi:
         end_time: str | pd.Timestamp | None = None,
         version: str | pd.Timestamp | None = None,
     ) -> pd.DataFrame:
-        """Run a v2 signal export query, returning the unprocessed server response as a DataFrame.
+        """Run a v2 signal export, returning the unprocessed server response as a DataFrame.
 
-        Use this when you need the full multi-level column structure from the server, for
+        Use this when you need the full multi-level column headers from the server, for
         example to access Bloomberg tickers or time series labels embedded in the column
-        headers. For a simpler interface that returns flat columns, use signal_query_v2().
+        headers. For a simpler interface that returns flat columns, use export_signals_v2().
 
         The returned DataFrame has:
         - A RangeIndex (integer rows).
         - The first column contains timestamps (column header is a tuple of level names).
-        - Remaining columns are a MultiIndex with levels
-          (Signal, Entity, Bloomberg ticker, Time series), where each column represents
-          one (signal, entity, time series) combination.
+        - Remaining columns are a MultiIndex. The levels present depend on the query
+          shape — Signal and a time-series level are always present; Entity,
+          Bloomberg ticker, and Currency levels may be present or absent depending on
+          whether the query targets entities and whether any signals carry currency
+          metadata. Index levels by name (e.g. ``get_level_values("Signal")``) rather
+          than by position when consuming this frame.
 
         Example::
 
-            df = export_api.run_signal_query_v2(
+            df = export_api.run_export_signals_v2(
                 signals=[
                     {"label": "Popularity", "expression": "graph_signal('ns.popularity')"},
                     {"label": "Revenue"},
@@ -246,21 +299,31 @@ class ExportApi:
             start_time=start_time,
             end_time=end_time,
             version=version,
-            output_format="pickle",
+            output_format="parquet",
         )
-        result_df = pickle.loads(content)
-        assert isinstance(result_df, pd.DataFrame)
-        return result_df
+        return pd.read_parquet(io.BytesIO(content))
 
     @staticmethod
     def _reshape_v2_response(
         df: pd.DataFrame,
         multi_entity: bool,
+        multi_ts_signals: frozenset[str],
     ) -> pd.DataFrame:
         """Reshape a v2 response DataFrame to the signal_query format.
 
-        The v2 response has MultiIndex columns (Signal, Entity, Bloomberg ticker, Time series)
-        with the first column containing timestamps and a RangeIndex for rows.
+        The v2 response has MultiIndex columns whose level names always include
+        "Signal" and "Time series", and may include "Entity", "Bloomberg ticker",
+        and "Currency" depending on the query shape. The first column holds
+        timestamps under a tuple of level names as header, and the row index is a
+        RangeIndex. Levels are addressed by name so server-side level reordering
+        or the addition of new levels does not silently mis-route columns.
+
+        Multi-ts signals keep the ``"{signal}/{ts_name}"`` column naming for
+        *every* entity, even one whose query happens to match a single sub-entity
+        — otherwise callers cannot tell which sub-entity that value belongs to.
+
+        ``multi_ts_signals`` is the authoritative set emitted by the server in
+        the parquet schema metadata (see ``_read_v2_parquet``).
         """
         time_values = pd.DatetimeIndex(df.iloc[:, 0])
         data_df = df.iloc[:, 1:]
@@ -271,20 +334,26 @@ class ExportApi:
             data_df.index.name = "time"
             return data_df
 
-        signal_labels = data_df.columns.get_level_values(0)
-        has_entity_level = data_df.columns.nlevels >= 4
+        level_names = data_df.columns.names
+        signal_labels = data_df.columns.get_level_values("Signal")
+        time_series_labels = data_df.columns.get_level_values("Time series")
+        has_entity_level = "Entity" in level_names
+        entity_labels = data_df.columns.get_level_values("Entity") if has_entity_level else None
+        unique_signals = list(dict.fromkeys(signal_labels))
+
+        def _column_name(sig: str, ts_name: str) -> str:
+            return f"{sig}/{ts_name}" if sig in multi_ts_signals else sig
 
         if has_entity_level and multi_entity:
-            entity_names = data_df.columns.get_level_values(1)
-            unique_entities = list(dict.fromkeys(entity_names))
-            unique_signals = list(dict.fromkeys(signal_labels))
-            ts_level = data_df.columns.nlevels - 1
+            assert entity_labels is not None  # narrowed by has_entity_level
+            unique_entities = list(dict.fromkeys(entity_labels))
 
             pieces = []
             for entity in unique_entities:
-                entity_mask = entity_names == entity
+                entity_mask = entity_labels == entity
                 entity_data = data_df.loc[:, entity_mask]
                 entity_signal_labels = signal_labels[entity_mask]
+                entity_ts_labels = time_series_labels[entity_mask]
 
                 entity_df = pd.DataFrame(index=time_values)
                 for sig in unique_signals:
@@ -292,12 +361,9 @@ class ExportApi:
                     sig_cols = entity_data.loc[:, sig_mask]
                     if sig_cols.shape[1] == 0:
                         continue
-                    if sig_cols.shape[1] == 1:
-                        entity_df[sig] = sig_cols.iloc[:, 0].values
-                    else:
-                        ts_names = data_df.columns.get_level_values(ts_level)[entity_mask][sig_mask]
-                        for i, ts_name in enumerate(ts_names):
-                            entity_df[f"{sig}/{ts_name}"] = sig_cols.iloc[:, i].values
+                    ts_names = entity_ts_labels[sig_mask]
+                    for i, ts_name in enumerate(ts_names):
+                        entity_df[_column_name(sig, ts_name)] = sig_cols.iloc[:, i].values
 
                 entity_df["__entity__"] = entity
                 pieces.append(entity_df)
@@ -311,22 +377,17 @@ class ExportApi:
         # Single entity or no entity level
         result = pd.DataFrame(index=time_values)
         result.index.name = "time"
-        unique_signals = list(dict.fromkeys(signal_labels))
-        ts_level = data_df.columns.nlevels - 1
 
         for sig in unique_signals:
             sig_mask = signal_labels == sig
             sig_cols = data_df.loc[:, sig_mask]
-            if sig_cols.shape[1] == 1:
-                result[sig] = sig_cols.iloc[:, 0].values
-            else:
-                ts_names = data_df.columns.get_level_values(ts_level)[sig_mask]
-                for i, ts_name in enumerate(ts_names):
-                    result[f"{sig}/{ts_name}"] = sig_cols.iloc[:, i].values
+            ts_names = time_series_labels[sig_mask]
+            for i, ts_name in enumerate(ts_names):
+                result[_column_name(sig, ts_name)] = sig_cols.iloc[:, i].values
 
         return result
 
-    def signal_query_v2(
+    def export_signals_v2(
         self,
         signal: str | Column | DerivedSignal | Sequence[str | Column | DerivedSignal],
         *,
@@ -336,7 +397,7 @@ class ExportApi:
         end_time: str | pd.Timestamp | None = None,
         version: str | pd.Timestamp | None = None,
     ) -> pd.Series | pd.DataFrame:
-        """Run a query for one or more signals using the v2 export endpoint.
+        """Export one or more signals using the v2 export endpoint.
 
         Unlike signal_query(), this method uses the v2 export API which supports
         multi-timeseries signals (e.g., expressions using for_type() that return one time
@@ -346,16 +407,16 @@ class ExportApi:
         For multi-timeseries signals, each time series becomes a separate column named
         ``"{signal_label}/{time_series_name}"`` (e.g., ``"Visits/domain1.com"``).
 
-        For access to the full server response with multi-level column headers (including
-        Bloomberg tickers and entity names), use run_signal_query_v2() instead.
+        For access to multi-level column headers (including Bloomberg tickers
+        and entity names), use run_export_signals_v2() instead.
 
         Example::
 
-            result = export_api.signal_query_v2(
+            result = export_api.export_signals_v2(
                 DerivedSignal(
                     name=None,
-                    label="sweb_visits",
-                    expression="data('similarweb.all_visits').for_type('similarweb.domain')",
+                    label="brand_sales",
+                    expression="data('sales').for_type('brand')",
                 ),
                 resource_name="entityTypes/company/entities/F_000C7F-E",
                 start_time="2024-01-01",
@@ -404,12 +465,112 @@ class ExportApi:
             start_time=start_time,
             end_time=end_time,
             version=version,
-            output_format="pickle",
+            output_format="parquet",
         )
-        raw_df = pickle.loads(content)
-        assert isinstance(raw_df, pd.DataFrame)
-        df = self._reshape_v2_response(raw_df, multi_entity=multi_entity)
+        raw_df, multi_ts_signals = _read_v2_parquet(content)
+        df = self._reshape_v2_response(
+            raw_df, multi_entity=multi_entity, multi_ts_signals=multi_ts_signals
+        )
         return df.squeeze(axis=1).infer_objects()
+
+    def export_signals_v2_bytes(
+        self,
+        signal: str | Column | DerivedSignal | Sequence[str | Column | DerivedSignal],
+        *,
+        file_format: str = "parquet",
+        resource_name: str | Sequence[str] | None = None,
+        tag: str | Sequence[str] | None = None,
+        start_time: str | pd.Timestamp | None = None,
+        end_time: str | pd.Timestamp | None = None,
+        version: str | pd.Timestamp | None = None,
+    ) -> bytes:
+        """Run a v2 signal export and return the raw response bytes.
+
+        Use this when you need the exported file bytes directly — e.g. to
+        persist to disk or forward to another system — without parsing them
+        into a DataFrame. This is the only v2 method that works without
+        ``pyarrow`` installed when ``file_format`` is ``csv``, ``excel``, or
+        ``json``; ``parquet`` and ``feather`` bytes come back fine but reading
+        them back as a DataFrame still requires ``pyarrow``.
+
+        Args:
+            signal:      the signal(s) to retrieve, same semantics as in
+                         :meth:`export_signals_v2`.
+            file_format: one of ``parquet``, ``feather``, ``csv``, ``excel``, ``json``.
+            resource_name: entity resource name(s) to evaluate for.
+            tag:         tag resource name(s) to evaluate for.
+            start_time:  first date to retrieve data for.
+            end_time:    last date to retrieve data for.
+            version:     point-in-time at which to evaluate the signals.
+        """
+        if not signal:
+            raise ValueError("Must specify signal to retrieve")
+        v2_signals = self._build_v2_signals(signal)
+        entities: list[str] | None = None
+        tags: list[str] | None = None
+        if resource_name is not None:
+            entities = [resource_name] if isinstance(resource_name, str) else list(resource_name)
+        if tag is not None:
+            tags = [tag] if isinstance(tag, str) else list(tag)
+        return self._post_v2_signals(
+            v2_signals,
+            entities=entities,
+            tags=tags,
+            start_time=start_time,
+            end_time=end_time,
+            version=version,
+            output_format=file_format,
+        )
+
+    def signal_query_v2(
+        self,
+        signal: str | Column | DerivedSignal | Sequence[str | Column | DerivedSignal],
+        *,
+        resource_name: str | Sequence[str] | None = None,
+        tag: str | Sequence[str] | None = None,
+        start_time: str | pd.Timestamp | None = None,
+        end_time: str | pd.Timestamp | None = None,
+        version: str | pd.Timestamp | None = None,
+    ) -> pd.Series | pd.DataFrame:
+        """Deprecated alias for :meth:`export_signals_v2`."""
+        warnings.warn(
+            "signal_query_v2 is deprecated, use export_signals_v2 instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.export_signals_v2(
+            signal,
+            resource_name=resource_name,
+            tag=tag,
+            start_time=start_time,
+            end_time=end_time,
+            version=version,
+        )
+
+    def run_signal_query_v2(
+        self,
+        signals: list[dict[str, str]],
+        *,
+        entities: list[str] | None = None,
+        tags: list[str] | None = None,
+        start_time: str | pd.Timestamp | None = None,
+        end_time: str | pd.Timestamp | None = None,
+        version: str | pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
+        """Deprecated alias for :meth:`run_export_signals_v2`."""
+        warnings.warn(
+            "run_signal_query_v2 is deprecated, use run_export_signals_v2 instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.run_export_signals_v2(
+            signals,
+            entities=entities,
+            tags=tags,
+            start_time=start_time,
+            end_time=end_time,
+            version=version,
+        )
 
     def signal_query(
         self,

--- a/exabel/scripts/export_signals_v2.py
+++ b/exabel/scripts/export_signals_v2.py
@@ -1,0 +1,168 @@
+import argparse
+import sys
+from datetime import timedelta
+from time import time
+from typing import Sequence
+
+import pandas as pd
+
+from exabel import ExabelClient
+from exabel.client.api.data_classes.derived_signal import DerivedSignal
+from exabel.scripts.base_script import BaseScript
+
+_EXTENSION_TO_FILE_FORMAT = {
+    "csv": "csv",
+    "xlsx": "excel",
+    "json": "json",
+    "feather": "feather",
+    "parquet": "parquet",
+}
+
+
+def _validate_filename(filename: str) -> str:
+    """Ensure the output file has one of the server-supported extensions."""
+    extension = filename.rsplit(".", 1)[-1].lower()
+    if extension not in _EXTENSION_TO_FILE_FORMAT:
+        raise argparse.ArgumentTypeError(
+            f"Unknown file extension {extension!r}. Supported: "
+            + ", ".join(f".{e}" for e in _EXTENSION_TO_FILE_FORMAT)
+        )
+    return filename
+
+
+def _parse_label_expression(value: str) -> DerivedSignal:
+    """Parse a ``LABEL=EXPRESSION`` CLI value into a DerivedSignal.
+
+    The label must be non-empty; the expression is everything after the first
+    ``=`` so expressions containing ``=`` themselves (e.g. comparisons) still
+    parse cleanly.
+    """
+    if "=" not in value:
+        raise argparse.ArgumentTypeError(
+            f"--expression value must be formatted as LABEL=EXPRESSION, got: {value!r}"
+        )
+    label, expression = value.split("=", 1)
+    label = label.strip()
+    expression = expression.strip()
+    if not label or not expression:
+        raise argparse.ArgumentTypeError(
+            f"--expression value must have non-empty LABEL and EXPRESSION, got: {value!r}"
+        )
+    return DerivedSignal(name=None, label=label, expression=expression)
+
+
+class ExportSignalsV2(BaseScript):
+    """Export time series using the v2 signal export endpoint and write the raw
+    server response to a file.
+
+    Unlike ``export_signals``, this supports multi-time-series signals (e.g.
+    signals whose expression uses ``for_type(...)`` and returns one series per
+    sub-entity). Entities must be specified by resource name or tag;
+    bloomberg_ticker / factset_id are not supported by the v2 endpoint.
+
+    The output file contains the server's wire response verbatim (no pandas
+    round-trip, no timezone normalization). Parquet and feather preserve the
+    full multi-level column headers; csv, excel, and json are flattened per the
+    server's serialization of those formats. Running this script does not
+    require ``pyarrow`` — only the SDK and a network connection.
+    """
+
+    def __init__(self, argv: Sequence[str], description: str):
+        super().__init__(argv, description)
+        self.parser.add_argument(
+            "--signal",
+            nargs="+",
+            required=False,
+            default=[],
+            type=str,
+            help=(
+                "Signal label(s) to export from the library. "
+                "At least one of --signal or --expression must be given."
+            ),
+        )
+        self.parser.add_argument(
+            "--expression",
+            nargs="+",
+            required=False,
+            default=[],
+            type=_parse_label_expression,
+            help=(
+                "DSL expression(s) to evaluate, each as LABEL=EXPRESSION. "
+                "The LABEL becomes the column name in the output. Example: "
+                "--expression "
+                '\'brand_sales=data("sales").for_type("brand")\''
+            ),
+        )
+        entity_group = self.parser.add_mutually_exclusive_group(required=True)
+        entity_group.add_argument(
+            "--resource-name",
+            nargs="+",
+            type=str,
+            help="Entity resource name(s) to evaluate the signal(s) for.",
+        )
+        entity_group.add_argument(
+            "--tag",
+            nargs="+",
+            type=str,
+            help="Tag(s) whose entities should be evaluated.",
+        )
+        self.parser.add_argument(
+            "--filename",
+            required=True,
+            type=_validate_filename,
+            help=(
+                "The filename to write the raw server response to. Supported extensions: "
+                + ", ".join(f".{e}" for e in _EXTENSION_TO_FILE_FORMAT)
+            ),
+        )
+        self.parser.add_argument(
+            "--start-date",
+            required=False,
+            type=pd.Timestamp,
+            help="The first date to evaluate the signals for.",
+        )
+        self.parser.add_argument(
+            "--end-date",
+            required=False,
+            type=pd.Timestamp,
+            help="The last date to evaluate the signals for.",
+        )
+        self.parser.add_argument(
+            "--known-time",
+            required=False,
+            type=pd.Timestamp,
+            help="The point-in-time at which to retrieve the time series.",
+        )
+
+    def run_script(self, client: ExabelClient, args: argparse.Namespace) -> None:
+        start_time = time()
+        signals: list[str | DerivedSignal] = [*args.signal, *args.expression]
+        if not signals:
+            self.parser.error("at least one of --signal or --expression must be provided")
+        signal_labels = [s if isinstance(s, str) else s.label for s in signals]
+        print("Downloading signal(s):", ", ".join(signal_labels))
+
+        extension = args.filename.rsplit(".", 1)[-1].lower()
+        file_format = _EXTENSION_TO_FILE_FORMAT[extension]
+
+        content = client.export_api.export_signals_v2_bytes(
+            signals,
+            file_format=file_format,
+            resource_name=args.resource_name,
+            tag=args.tag,
+            start_time=args.start_date,
+            end_time=args.end_date,
+            version=args.known_time,
+        )
+        with open(args.filename, "wb") as f:
+            f.write(content)
+
+        spent_time = timedelta(seconds=int(time() - start_time))
+        print(f"{len(content)} bytes written to {args.filename}, spent {spent_time}")
+
+
+if __name__ == "__main__":
+    ExportSignalsV2(
+        sys.argv,
+        "Export time series from the Exabel API for specified signals (v2 endpoint)",
+    ).run()

--- a/exabel/tests/client/api/test_export_api.py
+++ b/exabel/tests/client/api/test_export_api.py
@@ -1,9 +1,14 @@
+import io
 import json
 import pickle
 import re
+import warnings
+from typing import Sequence
 from unittest.mock import MagicMock
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from exabel.client.api.data_classes.derived_signal import DerivedSignal
@@ -177,22 +182,91 @@ class TestExportApi:
                 factset_id=["C", "D"],
             )
 
+    def test_run_query_bytes_warns_on_pickle(self):
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b""
+        export_api._session.post = MagicMock(return_value=mock_response)
+
+        with pytest.warns(DeprecationWarning, match="file_format='pickle' is deprecated"):
+            export_api.run_query_bytes("SELECT 1", file_format="pickle")
+
+        assert export_api._session.post.call_args[1]["data"]["format"] == "pickle"
+
+    def test_run_query_bytes_normalizes_pickle_casing(self):
+        """Case-insensitive detection also normalizes the wire value so the server,
+        which expects lowercase format keys, still accepts the request."""
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b""
+        export_api._session.post = MagicMock(return_value=mock_response)
+
+        with pytest.warns(DeprecationWarning):
+            export_api.run_query_bytes("SELECT 1", file_format="PICKLE")
+
+        assert export_api._session.post.call_args[1]["data"]["format"] == "pickle"
+
+    def test_run_query_uses_pickle_silently(self):
+        """``run_query`` requests pickle internally so v1 callers don't need
+        ``pyarrow`` installed, and it must not emit ``DeprecationWarning`` —
+        only the public ``run_query_bytes`` does that for explicit opt-in."""
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        frame = pd.DataFrame({"time": [pd.Timestamp("2024-03-31")], "Sales": [100]})
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = pickle.dumps(frame)
+        export_api._session.post = MagicMock(return_value=mock_response)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = export_api.run_query("SELECT time, Sales FROM signals")
+
+        call_args = export_api._session.post.call_args
+        assert call_args[1]["data"]["format"] == "pickle"
+        pd.testing.assert_frame_equal(result, frame)
+
 
 def _make_v2_response_df(
     time_values: list,
     columns: list[tuple],
     data: list[list],
+    level_names: tuple[str, ...] = ("Signal", "Entity", "Bloomberg ticker", "Time series"),
 ) -> pd.DataFrame:
     """Build a DataFrame matching the v2 export response format.
 
     The first column contains timestamps with a tuple of level names as header.
-    Remaining columns are MultiIndex tuples of (Signal, Entity, Bloomberg ticker, Time series).
+    Remaining columns are a MultiIndex with the given `level_names` — defaults to
+    the 4-level shape, override to exercise 3-level (no Entity), 5-level, or
+    Currency-present layouts.
     """
-    level_names = ("Signal", "Entity", "Bloomberg ticker", "Time series")
     time_col_name = level_names
     all_columns = pd.MultiIndex.from_tuples([time_col_name] + columns, names=level_names)
     all_data = {time_col_name: time_values, **dict(zip(columns, data))}
     return pd.DataFrame(all_data, columns=all_columns)
+
+
+def _df_to_parquet_bytes(
+    df: pd.DataFrame,
+    multi_ts_signals: Sequence[str] = (),
+) -> bytes:
+    """Serialize a test DataFrame to parquet bytes, matching the server's wire format.
+
+    Always embeds ``exabel_multi_ts_signals`` under the schema metadata key —
+    the real server guarantees the key is present (empty list when no multi-ts
+    signals participated), and the SDK treats an absent key as a contract
+    violation.
+    """
+    table = pa.Table.from_pandas(df)
+    metadata = {
+        **(table.schema.metadata or {}),
+        b"exabel_multi_ts_signals": json.dumps(sorted(multi_ts_signals)).encode("utf-8"),
+    }
+    table = table.replace_schema_metadata(metadata)
+    buffer = io.BytesIO()
+    pq.write_table(table, buffer)
+    return buffer.getvalue()
 
 
 class TestExportApiV2:
@@ -209,9 +283,9 @@ class TestExportApiV2:
         assert result == [{"label": "Sales_Actual"}]
 
     def test_build_v2_signals_derived_signal(self):
-        signal = DerivedSignal(name=None, label="sweb", expression="data('similarweb.visits')")
+        signal = DerivedSignal(name=None, label="brand_sales", expression="data('sales')")
         result = ExportApi._build_v2_signals(signal)
-        assert result == [{"label": "sweb", "expression": "data('similarweb.visits')"}]
+        assert result == [{"label": "brand_sales", "expression": "data('sales')"}]
 
     def test_build_v2_signals_sequence(self):
         signals = [
@@ -249,7 +323,7 @@ class TestExportApiV2:
         export_api = ExportApi(ClientConfig(api_key="api-key"))
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.content = pickle.dumps(pd.DataFrame())
+        mock_response.content = _df_to_parquet_bytes(pd.DataFrame({"x": [1]}))
         export_api._session.post = MagicMock(return_value=mock_response)
 
         export_api._post_v2_signals(
@@ -259,7 +333,6 @@ class TestExportApiV2:
             start_time="2024-01-01",
             end_time="2024-12-31",
             version="2024-06-01",
-            output_format="pickle",
         )
 
         call_args = export_api._session.post.call_args
@@ -273,7 +346,7 @@ class TestExportApiV2:
             "to": "2024-12-31T00:00:00Z",
         }
         assert body["version"] == "2024-06-01T00:00:00Z"
-        assert body["outputFormat"] == "pickle"
+        assert body["outputFormat"] == "parquet"
 
     def test_post_v2_signals_error(self):
         export_api = ExportApi(ClientConfig(api_key="api-key"))
@@ -283,10 +356,16 @@ class TestExportApiV2:
         export_api._session.post = MagicMock(return_value=mock_response)
 
         with pytest.raises(ValueError, match="Got 500: INTERNAL: Failed call"):
-            export_api._post_v2_signals(
-                [{"label": "sig"}],
-                output_format="pickle",
-            )
+            export_api._post_v2_signals([{"label": "sig"}])
+
+    def test_post_v2_signals_rejects_pickle(self):
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        export_api._session.post = MagicMock()
+
+        with pytest.raises(ValueError, match="pickle is not supported on the v2 export endpoint"):
+            export_api._post_v2_signals([{"label": "sig"}], output_format="pickle")
+
+        export_api._session.post.assert_not_called()
 
     def test_reshape_v2_response_single_entity_single_signal(self):
         times = [pd.Timestamp("2024-03-31"), pd.Timestamp("2024-06-30")]
@@ -296,7 +375,9 @@ class TestExportApiV2:
             data=[[100, 200]],
         )
 
-        result = ExportApi._reshape_v2_response(raw_df, multi_entity=False)
+        result = ExportApi._reshape_v2_response(
+            raw_df, multi_entity=False, multi_ts_signals=frozenset()
+        )
 
         assert list(result.columns) == ["Popularity"]
         assert list(result.index) == times
@@ -314,7 +395,9 @@ class TestExportApiV2:
             data=[[100, 200], [400, 300]],
         )
 
-        result = ExportApi._reshape_v2_response(raw_df, multi_entity=True)
+        result = ExportApi._reshape_v2_response(
+            raw_df, multi_entity=True, multi_ts_signals=frozenset()
+        )
 
         assert result.index.names == ["name", "time"]
         assert list(result.columns) == ["Popularity"]
@@ -333,7 +416,9 @@ class TestExportApiV2:
             data=[[100, 200], [400, 300], [1, 2]],
         )
 
-        result = ExportApi._reshape_v2_response(raw_df, multi_entity=True)
+        result = ExportApi._reshape_v2_response(
+            raw_df, multi_entity=True, multi_ts_signals=frozenset()
+        )
 
         assert result.index.names == ["name", "time"]
         assert sorted(result.columns) == ["Popularity", "Reputation"]
@@ -353,14 +438,160 @@ class TestExportApiV2:
             data=[[100], [200]],
         )
 
-        result = ExportApi._reshape_v2_response(raw_df, multi_entity=False)
+        result = ExportApi._reshape_v2_response(
+            raw_df, multi_entity=False, multi_ts_signals=frozenset({"Visits"})
+        )
 
         assert "Visits/domain1.com" in result.columns
         assert "Visits/domain2.com" in result.columns
         assert result["Visits/domain1.com"].iloc[0] == 100
         assert result["Visits/domain2.com"].iloc[0] == 200
 
-    def test_signal_query_v2_single_entity(self):
+    def test_reshape_v2_response_no_entity_level(self):
+        """3-level shape: (Signal, Time series, Currency) — dataset-scoped query with no entity."""
+        times = [pd.Timestamp("2024-03-31"), pd.Timestamp("2024-06-30")]
+        raw_df = _make_v2_response_df(
+            time_values=times,
+            columns=[("GDP", "USA", "")],
+            data=[[25000, 25500]],
+            level_names=("Signal", "Time series", "Currency"),
+        )
+
+        result = ExportApi._reshape_v2_response(
+            raw_df, multi_entity=False, multi_ts_signals=frozenset()
+        )
+
+        assert list(result.columns) == ["GDP"]
+        assert list(result.index) == times
+        assert list(result["GDP"]) == [25000, 25500]
+
+    def test_reshape_v2_response_with_currency_level_single_entity(self):
+        """4-level (Signal, Entity, Time series, Currency). Time series must not be
+        mis-read as Currency — the positional fallback 'last level' pointed at
+        Currency before the name-based refactor."""
+        times = [pd.Timestamp("2024-03-31")]
+        raw_df = _make_v2_response_df(
+            time_values=times,
+            columns=[("Revenue", "Company A", "Company A", "USD")],
+            data=[[1000]],
+            level_names=("Signal", "Entity", "Time series", "Currency"),
+        )
+
+        result = ExportApi._reshape_v2_response(
+            raw_df, multi_entity=False, multi_ts_signals=frozenset()
+        )
+
+        assert list(result.columns) == ["Revenue"]
+        assert result["Revenue"].iloc[0] == 1000
+
+    def test_reshape_v2_response_multi_ts_single_entity_match(self):
+        """When a multi-ts signal matches exactly one sub-entity for a given
+        entity, the SDK must still produce a "signal/sub_entity" column name
+        so the caller can tell which sub-entity the value belongs to —
+        multi-ts signals get the suffix for *every* entity, not just those
+        with multiple sub-entities in the result."""
+        times = [pd.Timestamp("2024-03-31")]
+        raw_df = _make_v2_response_df(
+            time_values=times,
+            columns=[
+                ("Visits", "Company A", "COMP US", "domain1.com"),
+                ("Visits", "Company A", "COMP US", "domain2.com"),
+                ("Visits", "Company B", "ANOT US", "domain1.com"),
+            ],
+            data=[[100], [200], [50]],
+        )
+
+        result = ExportApi._reshape_v2_response(
+            raw_df, multi_entity=True, multi_ts_signals=frozenset({"Visits"})
+        )
+
+        assert result.index.names == ["name", "time"]
+        assert result.loc["Company A", times[0]]["Visits/domain1.com"] == 100
+        assert result.loc["Company A", times[0]]["Visits/domain2.com"] == 200
+        assert result.loc["Company B", times[0]]["Visits/domain1.com"] == 50
+        assert "Visits" not in result.columns
+
+    def test_reshape_v2_response_with_currency_level_multi_entity_multi_ts(self):
+        """5-level shape with Currency present, multi-entity, multi-timeseries —
+        the most stress-testing shape for the name-based reshape."""
+        times = [pd.Timestamp("2024-03-31")]
+        raw_df = _make_v2_response_df(
+            time_values=times,
+            columns=[
+                ("Visits", "Company A", "COMP US", "domain1.com", ""),
+                ("Visits", "Company A", "COMP US", "domain2.com", ""),
+                ("Visits", "Company B", "ANOT US", "domain3.com", ""),
+                ("Visits", "Company B", "ANOT US", "domain4.com", ""),
+            ],
+            data=[[100], [200], [50], [75]],
+            level_names=("Signal", "Entity", "Bloomberg ticker", "Time series", "Currency"),
+        )
+
+        result = ExportApi._reshape_v2_response(
+            raw_df, multi_entity=True, multi_ts_signals=frozenset({"Visits"})
+        )
+
+        assert result.index.names == ["name", "time"]
+        assert result.loc["Company A", times[0]]["Visits/domain1.com"] == 100
+        assert result.loc["Company A", times[0]]["Visits/domain2.com"] == 200
+        assert result.loc["Company B", times[0]]["Visits/domain3.com"] == 50
+        assert result.loc["Company B", times[0]]["Visits/domain4.com"] == 75
+
+    def test_reshape_v2_response_multi_ts_with_name_collision(self):
+        """Regression for the review concern on #15390: a sub-entity whose
+        display name happens to equal its parent entity's display name (e.g.
+        a brand named "Nike Inc" under company "Nike Inc"). With server
+        metadata driving classification, the sub-entity still gets its
+        "BrandValue/Nike Inc" column — previous name-based heuristics
+        collapsed this to a bare "BrandValue".
+        """
+        times = [pd.Timestamp("2024-03-31")]
+        raw_df = _make_v2_response_df(
+            time_values=times,
+            columns=[("BrandValue", "Nike Inc", "NKE US", "Nike Inc")],
+            data=[[42]],
+        )
+
+        result = ExportApi._reshape_v2_response(
+            raw_df, multi_entity=False, multi_ts_signals=frozenset({"BrandValue"})
+        )
+
+        assert list(result.columns) == ["BrandValue/Nike Inc"]
+
+    def test_export_signals_v2_raises_on_missing_metadata(self):
+        """The SDK treats a response without ``exabel_multi_ts_signals`` as a
+        server contract violation — no silent fallback to heuristics."""
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        raw_df = pd.DataFrame({"time": [pd.Timestamp("2024-03-31")], "Sales": [100]})
+        buffer = io.BytesIO()
+        raw_df.to_parquet(buffer)
+        export_api._post_v2_signals = MagicMock(return_value=buffer.getvalue())
+
+        with pytest.raises(ValueError, match="exabel_multi_ts_signals"):
+            export_api.export_signals_v2("Sales", resource_name="entityTypes/company/entities/abc")
+
+    def test_export_signals_v2_reads_multi_ts_from_metadata(self):
+        """End-to-end: when the server embeds the metadata, the caller sees
+        ``{signal}/{ts_name}`` columns even in the name-collision case."""
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        times = [pd.Timestamp("2024-03-31")]
+        raw_df = _make_v2_response_df(
+            time_values=times,
+            columns=[("BrandValue", "Nike Inc", "NKE US", "Nike Inc")],
+            data=[[42]],
+        )
+        export_api._post_v2_signals = MagicMock(
+            return_value=_df_to_parquet_bytes(raw_df, multi_ts_signals=["BrandValue"])
+        )
+
+        result = export_api.export_signals_v2(
+            "BrandValue", resource_name="entityTypes/company/entities/nke"
+        )
+
+        assert isinstance(result, pd.Series)
+        assert result.name == "BrandValue/Nike Inc"
+
+    def test_export_signals_v2_single_entity(self):
         export_api = ExportApi(ClientConfig(api_key="api-key"))
         times = [pd.Timestamp("2024-03-31"), pd.Timestamp("2024-06-30")]
         raw_df = _make_v2_response_df(
@@ -368,10 +599,10 @@ class TestExportApiV2:
             columns=[("Sales", "Company A", "COMP US", "Company A")],
             data=[[100, 200]],
         )
-        mock_post = MagicMock(return_value=pickle.dumps(raw_df))
+        mock_post = MagicMock(return_value=_df_to_parquet_bytes(raw_df))
         export_api._post_v2_signals = mock_post
 
-        result = export_api.signal_query_v2(
+        result = export_api.export_signals_v2(
             "Sales",
             resource_name="entityTypes/company/entities/abc",
             start_time="2024-01-01",
@@ -387,7 +618,7 @@ class TestExportApiV2:
         assert call_kwargs[0][0] == [{"label": "Sales"}]
         assert call_kwargs[1]["entities"] == ["entityTypes/company/entities/abc"]
 
-    def test_signal_query_v2_multi_entity(self):
+    def test_export_signals_v2_multi_entity(self):
         export_api = ExportApi(ClientConfig(api_key="api-key"))
         times = [pd.Timestamp("2024-03-31"), pd.Timestamp("2024-06-30")]
         raw_df = _make_v2_response_df(
@@ -398,9 +629,9 @@ class TestExportApiV2:
             ],
             data=[[100, 200], [400, 300]],
         )
-        export_api._post_v2_signals = MagicMock(return_value=pickle.dumps(raw_df))
+        export_api._post_v2_signals = MagicMock(return_value=_df_to_parquet_bytes(raw_df))
 
-        result = export_api.signal_query_v2(
+        result = export_api.export_signals_v2(
             "Sales",
             resource_name=["entityTypes/company/entities/abc", "entityTypes/company/entities/def"],
         )
@@ -408,7 +639,7 @@ class TestExportApiV2:
         assert isinstance(result, pd.Series)
         assert result.index.names == ["name", "time"]
 
-    def test_signal_query_v2_with_tag(self):
+    def test_export_signals_v2_with_tag(self):
         export_api = ExportApi(ClientConfig(api_key="api-key"))
         times = [pd.Timestamp("2024-03-31")]
         raw_df = _make_v2_response_df(
@@ -416,46 +647,46 @@ class TestExportApiV2:
             columns=[("Sales", "Company A", "COMP US", "Company A")],
             data=[[100]],
         )
-        mock_post = MagicMock(return_value=pickle.dumps(raw_df))
+        mock_post = MagicMock(return_value=_df_to_parquet_bytes(raw_df))
         export_api._post_v2_signals = mock_post
 
-        export_api.signal_query_v2("Sales", tag="tags/user:123")
+        export_api.export_signals_v2("Sales", tag="tags/user:123")
 
         assert mock_post.call_args[1]["tags"] == ["tags/user:123"]
 
-    def test_signal_query_v2_with_derived_signal(self):
+    def test_export_signals_v2_with_derived_signal(self):
         export_api = ExportApi(ClientConfig(api_key="api-key"))
         times = [pd.Timestamp("2024-03-31")]
         raw_df = _make_v2_response_df(
             time_values=times,
-            columns=[("sweb", "Company A", "COMP US", "Company A")],
+            columns=[("brand_sales", "Company A", "COMP US", "Company A")],
             data=[[42]],
         )
-        export_api._post_v2_signals = MagicMock(return_value=pickle.dumps(raw_df))
+        export_api._post_v2_signals = MagicMock(return_value=_df_to_parquet_bytes(raw_df))
 
         signal = DerivedSignal(
             name=None,
-            label="sweb",
-            expression="data('similarweb.all_visits').for_type('similarweb.domain')",
+            label="brand_sales",
+            expression="data('sales').for_type('brand')",
         )
-        result = export_api.signal_query_v2(
+        result = export_api.export_signals_v2(
             signal, resource_name="entityTypes/company/entities/abc"
         )
 
         call_args = export_api._post_v2_signals.call_args[0][0]
         assert call_args == [
             {
-                "label": "sweb",
-                "expression": "data('similarweb.all_visits').for_type('similarweb.domain')",
+                "label": "brand_sales",
+                "expression": "data('sales').for_type('brand')",
             }
         ]
 
-    def test_signal_query_v2_empty_signal_raises(self):
+    def test_export_signals_v2_empty_signal_raises(self):
         export_api = ExportApi(ClientConfig(api_key="api-key"))
         with pytest.raises(ValueError, match="Must specify signal to retrieve"):
-            export_api.signal_query_v2([], resource_name="entityTypes/company/entities/abc")
+            export_api.export_signals_v2([], resource_name="entityTypes/company/entities/abc")
 
-    def test_run_signal_query_v2(self):
+    def test_run_export_signals_v2(self):
         export_api = ExportApi(ClientConfig(api_key="api-key"))
         times = [pd.Timestamp("2024-03-31"), pd.Timestamp("2024-06-30")]
         raw_df = _make_v2_response_df(
@@ -465,10 +696,10 @@ class TestExportApiV2:
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.content = pickle.dumps(raw_df)
+        mock_response.content = _df_to_parquet_bytes(raw_df)
         export_api._session.post = MagicMock(return_value=mock_response)
 
-        result_df = export_api.run_signal_query_v2(
+        result_df = export_api.run_export_signals_v2(
             [{"label": "Sales"}],
             entities=["entityTypes/company/entities/abc"],
             start_time="2024-01-01",
@@ -480,10 +711,87 @@ class TestExportApiV2:
         assert isinstance(result_df.columns, pd.MultiIndex)
         assert result_df.shape == (2, 2)  # time column + 1 data column
 
+    def test_export_signals_v2_bytes_returns_raw_response(self):
+        """``export_signals_v2_bytes`` posts the v2 request in the requested format
+        and returns the server's raw bytes unchanged — no pyarrow parsing."""
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        wire_bytes = b"time,Sales\n2024-03-31,100\n"
+        mock_post = MagicMock(return_value=wire_bytes)
+        export_api._post_v2_signals = mock_post
+
+        result = export_api.export_signals_v2_bytes(
+            "Sales",
+            file_format="csv",
+            resource_name="entityTypes/company/entities/abc",
+            start_time="2024-01-01",
+            end_time="2024-12-31",
+        )
+
+        assert result == wire_bytes
+        assert mock_post.call_args[1]["output_format"] == "csv"
+        assert mock_post.call_args[1]["entities"] == ["entityTypes/company/entities/abc"]
+
+    def test_export_signals_v2_bytes_empty_signal_raises(self):
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        with pytest.raises(ValueError, match="Must specify signal to retrieve"):
+            export_api.export_signals_v2_bytes([], resource_name="entityTypes/company/entities/abc")
+
+    def test_export_signals_v2_bytes_rejects_pickle(self):
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        export_api._session.post = MagicMock()
+
+        with pytest.raises(ValueError, match="pickle is not supported on the v2 export endpoint"):
+            export_api.export_signals_v2_bytes(
+                "Sales",
+                file_format="pickle",
+                resource_name="entityTypes/company/entities/abc",
+            )
+
+        export_api._session.post.assert_not_called()
+
+    def test_signal_query_v2_emits_deprecation_warning(self):
+        """The old name remains a thin wrapper that delegates to
+        ``export_signals_v2`` with a ``DeprecationWarning``."""
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        times = [pd.Timestamp("2024-03-31")]
+        raw_df = _make_v2_response_df(
+            time_values=times,
+            columns=[("Sales", "Company A", "COMP US", "Company A")],
+            data=[[100]],
+        )
+        export_api._post_v2_signals = MagicMock(return_value=_df_to_parquet_bytes(raw_df))
+
+        with pytest.warns(DeprecationWarning, match="signal_query_v2 is deprecated"):
+            result = export_api.signal_query_v2(
+                "Sales", resource_name="entityTypes/company/entities/abc"
+            )
+        assert isinstance(result, pd.Series)
+
+    def test_run_signal_query_v2_emits_deprecation_warning(self):
+        export_api = ExportApi(ClientConfig(api_key="api-key"))
+        times = [pd.Timestamp("2024-03-31")]
+        raw_df = _make_v2_response_df(
+            time_values=times,
+            columns=[("Sales", "Company A", "COMP US", "Company A")],
+            data=[[100]],
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = _df_to_parquet_bytes(raw_df)
+        export_api._session.post = MagicMock(return_value=mock_response)
+
+        with pytest.warns(DeprecationWarning, match="run_signal_query_v2 is deprecated"):
+            result = export_api.run_signal_query_v2(
+                [{"label": "Sales"}], entities=["entityTypes/company/entities/abc"]
+            )
+        assert isinstance(result, pd.DataFrame)
+
     def test_reshape_v2_response_non_multiindex(self):
         flat_df = pd.DataFrame({"time": [pd.Timestamp("2024-03-31")], "Sales": [100]})
 
-        result = ExportApi._reshape_v2_response(flat_df, multi_entity=False)
+        result = ExportApi._reshape_v2_response(
+            flat_df, multi_entity=False, multi_ts_signals=frozenset()
+        )
 
         assert result.index.name == "time"
         assert list(result.columns) == ["Sales"]

--- a/exabel/tests/scripts/test_export_signals_v2.py
+++ b/exabel/tests/scripts/test_export_signals_v2.py
@@ -1,0 +1,273 @@
+import argparse
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from exabel.client.api.data_classes.derived_signal import DerivedSignal
+from exabel.scripts.export_signals_v2 import ExportSignalsV2
+
+
+class TestExportSignalsV2(unittest.TestCase):
+    def setUp(self):
+        self.common_args = [
+            "script",
+            "--signal",
+            "signalA",
+            "signalB",
+            "--start-date",
+            "2023-01-31",
+            "--end-date",
+            "2024-02-29",
+            "--filename",
+        ]
+
+    def _assert_common_args(self, args: argparse.Namespace):
+        assert args.signal == ["signalA", "signalB"]
+        assert args.start_date == pd.Timestamp("2023-01-31")
+        assert args.end_date == pd.Timestamp("2024-02-29")
+
+    def test_args_with_tag(self):
+        script = ExportSignalsV2(
+            self.common_args
+            + [
+                "foo.csv",
+                "--tag",
+                "tags/user:1",
+                "tags/user:2",
+                "--api-key",
+                "api-key",
+            ],
+            "desc",
+        )
+        args = script.parse_arguments()
+        self._assert_common_args(args)
+        assert args.filename == "foo.csv"
+        assert args.tag == ["tags/user:1", "tags/user:2"]
+        assert args.resource_name is None
+        assert args.api_key == "api-key"
+
+    def test_args_with_resource_name(self):
+        script = ExportSignalsV2(
+            self.common_args
+            + [
+                "foo.parquet",
+                "--resource-name",
+                "entityTypes/company/entities/A",
+                "entityTypes/company/entities/B",
+                "--api-key",
+                "api-key",
+            ],
+            "desc",
+        )
+        args = script.parse_arguments()
+        self._assert_common_args(args)
+        assert args.filename == "foo.parquet"
+        assert args.resource_name == [
+            "entityTypes/company/entities/A",
+            "entityTypes/company/entities/B",
+        ]
+        assert args.tag is None
+
+    def test_args_env_variable(self):
+        os.environ["EXABEL_API_KEY"] = "env_key"
+        try:
+            script = ExportSignalsV2(
+                self.common_args
+                + [
+                    "foo.csv",
+                    "--tag",
+                    "tags/user:1",
+                ],
+                "desc",
+            )
+            args = script.parse_arguments()
+            self._assert_common_args(args)
+            assert args.api_key is None
+            assert args.filename == "foo.csv"
+        finally:
+            del os.environ["EXABEL_API_KEY"]
+
+    def test_args_known_time(self):
+        script = ExportSignalsV2(
+            self.common_args
+            + [
+                "foo.csv",
+                "--tag",
+                "tags/user:1",
+                "--api-key",
+                "api-key",
+                "--known-time",
+                "2024-01-03",
+            ],
+            "desc",
+        )
+        args = script.parse_arguments()
+        assert args.known_time == pd.Timestamp("2024-01-03")
+
+    def test_args_requires_entity_selector(self):
+        script = ExportSignalsV2(self.common_args + ["foo.csv", "--api-key", "api-key"], "desc")
+        with pytest.raises(SystemExit):
+            script.parse_arguments()
+
+    def test_args_tag_and_resource_name_mutually_exclusive(self):
+        script = ExportSignalsV2(
+            self.common_args
+            + [
+                "foo.csv",
+                "--tag",
+                "tags/user:1",
+                "--resource-name",
+                "entityTypes/company/entities/A",
+                "--api-key",
+                "api-key",
+            ],
+            "desc",
+        )
+        with pytest.raises(SystemExit):
+            script.parse_arguments()
+
+    def test_args_unknown_file_extension(self):
+        script = ExportSignalsV2(
+            self.common_args
+            + [
+                "foo.pdf",
+                "--tag",
+                "tags/user:1",
+                "--api-key",
+                "api-key",
+            ],
+            "desc",
+        )
+        with pytest.raises(SystemExit):
+            script.parse_arguments()
+
+    def test_args_expression_only(self):
+        """--expression alone (no --signal) should parse and produce DerivedSignal objects."""
+        script = ExportSignalsV2(
+            [
+                "script",
+                "--expression",
+                'brand_sales=data("sales").for_type("brand")',
+                "--start-date",
+                "2023-01-31",
+                "--end-date",
+                "2024-02-29",
+                "--filename",
+                "foo.csv",
+                "--tag",
+                "tags/user:1",
+                "--api-key",
+                "api-key",
+            ],
+            "desc",
+        )
+        args = script.parse_arguments()
+        assert args.signal == []
+        assert len(args.expression) == 1
+        derived = args.expression[0]
+        assert isinstance(derived, DerivedSignal)
+        assert derived.label == "brand_sales"
+        assert derived.expression == 'data("sales").for_type("brand")'
+
+    def test_args_expression_without_equals_sign_raises(self):
+        script = ExportSignalsV2(
+            [
+                "script",
+                "--expression",
+                "missing_separator",
+                "--filename",
+                "foo.csv",
+                "--tag",
+                "tags/user:1",
+                "--api-key",
+                "api-key",
+            ],
+            "desc",
+        )
+        with pytest.raises(SystemExit):
+            script.parse_arguments()
+
+    def test_args_expression_preserves_equals_in_expression_body(self):
+        """`=` inside the expression must not confuse the label split."""
+        script = ExportSignalsV2(
+            [
+                "script",
+                "--expression",
+                'cmp=data("x") == 1',
+                "--filename",
+                "foo.csv",
+                "--tag",
+                "tags/user:1",
+                "--api-key",
+                "api-key",
+            ],
+            "desc",
+        )
+        args = script.parse_arguments()
+        derived = args.expression[0]
+        assert derived.label == "cmp"
+        assert derived.expression == 'data("x") == 1'
+
+    def test_run_script_writes_raw_bytes_and_derives_format_from_extension(self):
+        """`run_script` calls ``export_signals_v2_bytes`` with the format
+        derived from the file extension and writes the returned bytes to
+        disk verbatim (no pandas round-trip)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            filename = str(Path(tmp) / "out.csv")
+            wire_bytes = b"time,Sales\n2024-03-31,100\n"
+            script = ExportSignalsV2(
+                self.common_args
+                + [
+                    filename,
+                    "--tag",
+                    "tags/user:1",
+                    "--api-key",
+                    "api-key",
+                ],
+                "desc",
+            )
+            args = script.parse_arguments()
+
+            client = MagicMock()
+            client.export_api.export_signals_v2_bytes = MagicMock(return_value=wire_bytes)
+
+            script.run_script(client, args)
+
+            client.export_api.export_signals_v2_bytes.assert_called_once()
+            kwargs = client.export_api.export_signals_v2_bytes.call_args.kwargs
+            assert kwargs["file_format"] == "csv"
+            assert kwargs["tag"] == ["tags/user:1"]
+            assert kwargs["start_time"] == pd.Timestamp("2023-01-31")
+            assert kwargs["end_time"] == pd.Timestamp("2024-02-29")
+            assert Path(filename).read_bytes() == wire_bytes
+
+    def test_run_script_derives_excel_format_from_xlsx_extension(self):
+        """``.xlsx`` maps to ``file_format='excel'``, not the literal extension."""
+        with tempfile.TemporaryDirectory() as tmp:
+            filename = str(Path(tmp) / "out.xlsx")
+            script = ExportSignalsV2(
+                self.common_args
+                + [
+                    filename,
+                    "--tag",
+                    "tags/user:1",
+                    "--api-key",
+                    "api-key",
+                ],
+                "desc",
+            )
+            args = script.parse_arguments()
+
+            client = MagicMock()
+            client.export_api.export_signals_v2_bytes = MagicMock(return_value=b"PK\x03\x04")
+
+            script.run_script(client, args)
+
+            assert (
+                client.export_api.export_signals_v2_bytes.call_args.kwargs["file_format"] == "excel"
+            )

--- a/exabel/tests/scripts/test_load_relationships_from_csv.py
+++ b/exabel/tests/scripts/test_load_relationships_from_csv.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from exabel import ExabelClient
 from exabel.client.api.data_classes.relationship import Relationship
 from exabel.scripts.load_relationships_from_csv import LoadRelationshipsFromCsv
@@ -21,6 +23,11 @@ common_args_with_entity_to_column = common_args + [
 
 
 class TestLoadRelationships:
+    pytestmark = pytest.mark.filterwarnings(
+        "ignore:The 'entity_from' and 'entity_to' columns:"
+        "exabel.util.warnings.ExabelDeprecationWarning"
+    )
+
     def check_relationships(self, client: ExabelClient, expected_relationships: list[Relationship]):
         """Check expected entities against actual entities retrieved from the client"""
         relationship_type = expected_relationships[0].relationship_type

--- a/exabel/tests/services/test_csv_relationship_loader.py
+++ b/exabel/tests/services/test_csv_relationship_loader.py
@@ -190,6 +190,11 @@ class TestRelationshipLoaderColumnConfiguration:
 
 
 class TestCsvRelationshipLoader(unittest.TestCase):
+    pytestmark = pytest.mark.filterwarnings(
+        "ignore:The 'entity_from' and 'entity_to' columns:"
+        "exabel.util.warnings.ExabelDeprecationWarning"
+    )
+
     def test_load_relationships_with_properties(self):
         client: ExabelClient = ExabelMockClient()
         CsvRelationshipLoader(client).load_relationships(

--- a/exabel/tests/util/test_resource_name_normalization.py
+++ b/exabel/tests/util/test_resource_name_normalization.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -33,7 +34,7 @@ class TestResourceNameNormalization:
             [
                 "entityTypes/BRAND/entities/acme.abc_Inc_",
                 "entityTypes/BRAND/entities/acme.abcXYZ0189-_",
-                None,
+                np.nan,
                 "entityTypes/BRAND/entities/acme._l_",
             ],
             name="entity",
@@ -49,7 +50,7 @@ class TestResourceNameNormalization:
             [
                 "entityTypes/brand/entities/acme.abc_Inc_",
                 "entityTypes/brand/entities/acme.abcXYZ0189-_",
-                None,
+                np.nan,
                 "entityTypes/brand/entities/acme._l_",
             ],
             name="entity",
@@ -65,7 +66,7 @@ class TestResourceNameNormalization:
             [
                 "entityTypes/country/entities/I_DE",
                 "entityTypes/country/entities/I_US",
-                None,
+                np.nan,
                 "entityTypes/country/entities/abcXYZ0189",
             ],
             name="entity",
@@ -226,11 +227,11 @@ class TestResourceNameNormalization:
             [
                 "entityTypes/company/entities/telenor_asa",
                 "entityTypes/company/entities/apple_inc",
-                None,
-                None,
+                np.nan,
+                np.nan,
                 "entityTypes/company/entities/orkla_asa",
-                None,
-                None,
+                np.nan,
+                np.nan,
             ],
             name="entity",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "ruff",
     "mypy",
     "pytest",
+    "pyarrow",
     "types-protobuf",
     "types-python-dateutil",
     "types-requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "exabel"
 description = "Python SDK for the Exabel Data API"
-version = "8.1.0"
+version = "8.2.0"
 license = "MIT"
 license-files = ["LICENSE"]
 readme = "README.md"
@@ -44,6 +44,7 @@ dev = [
 snowflake = ["snowflake-connector-python[pandas]", "snowflake-sqlalchemy"]
 bigquery = ["google-cloud-bigquery", "sqlalchemy-bigquery"]
 athena = ["pyathena", "pyarrow", "sqlalchemy"]
+export = ["pyarrow"]
 
 [project.urls]
 Homepage = "https://github.com/Exabel/python-sdk"
@@ -124,7 +125,15 @@ select = [
     "B006",    # mutable-argument-default
     "B018",    # useless-expression
     "B023",    # function-uses-loop-variable
-    "S307",    # suspicious-eval-usage
+    "S",       # flake8-bandit (security)
+
+    "TRY002",  # raise-vanilla-class
+    "RUF",     # ruff-specific rules
+    "PIE",     # flake8-pie (misc. lints)
+    "PERF",    # perflint (performance)
+    "RET",     # flake8-return
+    "ASYNC",   # flake8-async
+    "SIM",     # flake8-simplify
 
     # pydocstyle
     "D101",    # undocumented-public-class
@@ -138,6 +147,10 @@ select = [
     "UP032",    # f-string
     "UP037",    # do not need quotes for type annotations
     "UP045",    # use X | None instead of Optional[X]
+
+    # disabled for now
+    # "B",      # flake8-bugbear
+    # "PT009",  # pytest-unittest-assertion
 ]
 
 ignore = [
@@ -146,7 +159,7 @@ ignore = [
     "E721",  # type-comparison
     "E741",  # ambiguous-variable-name
 
-    # Matches pylint disabled rules in [tool.pylint.messages_control]
+    # pylint disabled rules
     "PLC0415",  # import-outside-toplevel
     "PLR0904",  # too-many-public-methods
     "PLR0911",  # too-many-return-statements
@@ -186,6 +199,46 @@ ignore = [
 
     "G010",  # logging-warn
     "G201",  # logging-exc-info - use .exception() instead of .error() with exc_info=true
+
+    # bandit rules that are too noisy or not applicable in this codebase
+    "S101",   # assert - legitimate use for invariants outside tests
+    "S104",   # hardcoded-bind-all-interfaces - intentional in server code
+    "S105",   # hardcoded-password-string - false positives on GCloud secret ID names
+    "S108",   # hardcoded-temp-file - used in mock/test utilities
+    "S110",   # try-except-pass - established pattern in the codebase
+    "S112",   # try-except-continue - established pattern in the codebase
+    "S301",   # suspicious-pickle-usage - used intentionally for serialization
+    "S311",   # suspicious-non-cryptographic-random-usage - acceptable for ML/sampling
+    "S324",   # hashlib-insecure-hash-function - used for checksums, not crypto
+    "S603",   # subprocess-without-shell-equals-true - many legitimate uses
+    "S607",   # start-process-with-partial-path - noisy on internal scripts
+    "S608",   # hardcoded-sql-expression - internal query construction, not user input
+
+    # ruff-specific rules
+    "RUF001",  # ambiguous-unicode-character-string
+    "RUF002",  # ambiguous-unicode-character-docstring
+    "RUF003",  # ambiguous-unicode-character-comment
+    "RUF005",  # collection-literal-concatenation - [*a, *b] vs a + b is a style choice
+    "RUF009",  # function-call-in-dataclass-default-argument - intentional pattern
+    "RUF012",  # mutable-class-default - intentional in many classes
+
+    # flake8-simplify
+    "SIM102",  # collapsible-if - often clearer as separate ifs
+    "SIM105",  # suppressible-exception - contextlib.suppress not always clearer
+    "SIM108",  # if-else-block-instead-of-if-exp - ternary not always more readable
+    "SIM117",  # multiple-with-statements - combining withs can reduce readability
+    "SIM300",  # yoda-conditions - established style in the codebase
+
+    # flake8-return
+    "RET504",  # unnecessary-assign - named returns improve readability
+
+    # perflint
+    "PERF102",  # incorrect-dict-iterator - unsafe for pandas DataFrame/Series (.values is a property)
+    "PERF203",  # try-except-in-loop - auto-suppressed in monorepo (py311 target, zero-cost exceptions); SDK targets py310
+    "PERF401",  # manual-list-comprehension - too many existing violations, fix incrementally
+
+    # flake8-async
+    "ASYNC109",  # async-function-with-timeout - false positives on internal timeout patterns
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -195,7 +248,10 @@ ignore = [
     "ARG001",  # unused-function-argument
     "ARG002",  # unused-method-argument
     "D",  # pydocstyle
-    "SLF001"  # private-member-access
+    "S",  # bandit - tests use hardcoded values, subprocess, etc.
+    "SLF001",  # private-member-access
+    "RUF043",  # pytest-raises-ambiguous-pattern
+    "RUF061",  # legacy-form-pytest-raises
 ]
 "**/__init__.py" = ["F401"] # unused-import
 
@@ -210,6 +266,9 @@ extend-ignore-names = ["_*", "of*", "__*", "X*"]
 convention = "google"
 ignore-decorators = ["typing.overload"]
 ignore-var-parameters = true
+
+[tool.ruff.lint.flake8-bandit]
+check-typed-exception = true
 
 [tool.ruff.lint.flake8-unused-arguments]
 ignore-variadic-names = true

--- a/uv.lock
+++ b/uv.lock
@@ -348,6 +348,7 @@ snowflake = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "types-protobuf" },
@@ -379,6 +380,7 @@ provides-extras = ["snowflake", "bigquery", "athena", "export"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "types-protobuf" },

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "exabel"
-version = "8.1.0"
+version = "8.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-core" },
@@ -336,6 +336,9 @@ athena = [
 bigquery = [
     { name = "google-cloud-bigquery" },
     { name = "sqlalchemy-bigquery" },
+]
+export = [
+    { name = "pyarrow" },
 ]
 snowflake = [
     { name = "snowflake-connector-python", extra = ["pandas"] },
@@ -362,6 +365,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "protobuf", specifier = ">=6" },
     { name = "pyarrow", marker = "extra == 'athena'" },
+    { name = "pyarrow", marker = "extra == 'export'" },
     { name = "pyathena", marker = "extra == 'athena'" },
     { name = "requests" },
     { name = "snowflake-connector-python", extras = ["pandas"], marker = "extra == 'snowflake'" },
@@ -370,7 +374,7 @@ requires-dist = [
     { name = "sqlalchemy-bigquery", marker = "extra == 'bigquery'" },
     { name = "tqdm" },
 ]
-provides-extras = ["snowflake", "bigquery", "athena"]
+provides-extras = ["snowflake", "bigquery", "athena", "export"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Added

- New v2 export methods in `ExportApi`: `export_signals_v2`,
  `run_export_signals_v2`, and `export_signals_v2_bytes`.
- New CLI script `exabel.scripts.export_signals_v2` that runs a v2 signal
  export and writes the raw server response to disk. Output format is
  selected by the `--filename` extension (`.csv`, `.xlsx`, `.json`,
  `.feather`, `.parquet`).
- New optional dependency group `export`. Install with
  `pip install 'exabel[export]'`.

## Changed

- `pyarrow` is required for `export_signals_v2` and `run_export_signals_v2`.

## Deprecated

- `signal_query_v2` and `run_signal_query_v2` are deprecated; use
  `export_signals_v2` and `run_export_signals_v2` instead.
- `run_query_bytes` with `file_format="pickle"` is deprecated.

## Removed

- The v2 export endpoint no longer accepts `output_format="pickle"`.
